### PR TITLE
Choosing materials from a material database

### DIFF
--- a/src/TASOPT.jl
+++ b/src/TASOPT.jl
@@ -31,6 +31,9 @@ include("./misc/units.jl")
 export convertMass, convertForce, convertDist, 
        convertSpeed, convertPower, convertAngle
 
+include("./misc/materials.jl")
+export StructuralAlloy, Conductor, Insulator
+
 include("./misc/index.inc")
 include("./misc/aircraft.jl")
 export aircraft

--- a/src/TASOPT.jl
+++ b/src/TASOPT.jl
@@ -6,7 +6,7 @@ module TASOPT
 export atmos, size_aircraft!
 
 # Add basic pacakges required by TASOPT
-using Base: SignedMultiplicativeInverse
+using Base: SignedMultiplicativeInverse, @kwdef
 using NLopt: G_MLSL_LDS, GN_MLSL_LDS, GN_CRS2_LM, GN_DIRECT_L
 
 using BenchmarkTools

--- a/src/material_data/MaterialProperties.toml
+++ b/src/material_data/MaterialProperties.toml
@@ -18,7 +18,7 @@
 
 [Al-7075]
     description = """General 7075 characteristics and uses (from Alcoa): Very high strength material used for highly stressed structural parts. The T7351 temper offers improved stress-corrosion cracking resistance.
-                     Uses: Aircraft fittings, gears and shafts, fuse parts, meter shafts and gears, missile parts, regulating valve parts, worm gears, keys, aircraft, aerospace and defense applications."""
+    Uses: Aircraft fittings, gears and shafts, fuse parts, meter shafts and gears, missile parts, regulating valve parts, worm gears, keys, aircraft, aerospace and defense applications."""
 
     source = "https://www.matweb.com/search/DataSheet.aspx?MatGUID=6653b72914864cc0a0ff7adf5b720167"
     density = 2810.0 #kg/m3

--- a/src/material_data/MaterialProperties.toml
+++ b/src/material_data/MaterialProperties.toml
@@ -1,0 +1,72 @@
+# Default Material Properties for commonly used materials in TASOPT
+# All units are assumed to be in SI units
+[Al-6061]
+    description = "Aluminium 6061 alloy"
+    #Structural properties taken from here: https://www.matweb.com/search/DataSheet.aspx?MatGUID=626ec8cdca604f1994be4fc2bc6f7f63 
+    density = 2700.0 #kg/m3
+    youngs_modulus = 68.9e9 #Pa
+    shear_modulus = 26.0e9 #Pa
+    poissons_ratio = 0.33
+    YTS = 55.2e6 #Yield tensile strength
+    UTS = 124e6  #Ultimate tensile strength
+    shear_strength = 82.7e6
+
+    #Electrical properties taken from here: https://en.wikipedia.org/wiki/Electrical_resistivity_and_conductivity#Resistivity_and_conductivity_of_various_materials 
+    resistivity = 2.65e-8
+    alpha = 3.90e-3
+    T0 = 293.15
+
+[Ti-6242]
+    description = "Titanium 6242 alloy"
+    #Structural properties: https://www.matweb.com/search/datasheet_print.aspx?matguid=66f20965748441d8916768ed80be0cba
+    density = 4540.0 #kg/m3
+    youngs_modulus = 120e9 #Pa
+    shear_modulus = 45.5e9 #Pa
+    poissons_ratio = 0.32
+    YTS = 990e6 #Yield tensile strength
+    UTS = 1010e6  #Ultimate tensile strength
+    shear_strength = 82.7e6
+
+# -----------------------------------------------------
+# Generic conductors with electrical properties taken 
+# from here: https://en.wikipedia.org/wiki/Electrical_resistivity_and_conductivity#Resistivity_and_conductivity_of_various_materials 
+# -----------------------------------------------------
+[Cu]
+    description = "Generic copper"
+    density = 8960.0
+    resistivity = 1.68e-8
+    alpha = 4.04e-3
+    T0 = 293.15
+
+[Au]
+    description = "Generic gold"
+    density = 19300.0
+    resistivity = 2.44e-8
+    alpha = 3.40e-3
+    T0 = 293.15
+
+[Ag]
+    description = "Generic silver"
+    density = 10490.0
+    resistivity = 1.59e-8
+    alpha = 3.80e-3
+    T0 = 293.15
+
+# -----------------------------------------------------
+# Generic insulators
+# -----------------------------------------------------
+[PTFE]
+    description = ""
+    density = 2150.0
+    dielectric_strength = 19.7e6
+
+[PEEK]
+    description = ""
+    density = 1320.0
+    dielectric_strength = 23e6
+
+[polyamide]
+    description = "Generic polyamide"
+    #Dowdle et al https://doi.org/10.2514/6.2018-5026
+    density = 1700.0
+    dielectric_strength = 10e6

--- a/src/material_data/MaterialProperties.toml
+++ b/src/material_data/MaterialProperties.toml
@@ -2,7 +2,7 @@
 # All units are assumed to be in SI units
 [Al-6061]
     description = "Aluminium 6061 alloy"
-    #Structural properties taken from here: https://www.matweb.com/search/DataSheet.aspx?MatGUID=626ec8cdca604f1994be4fc2bc6f7f63 
+    source = "https://www.matweb.com/search/DataSheet.aspx?MatGUID=626ec8cdca604f1994be4fc2bc6f7f63"
     density = 2700.0 #kg/m3
     youngs_modulus = 68.9e9 #Pa
     shear_modulus = 26.0e9 #Pa
@@ -15,6 +15,19 @@
     resistivity = 2.65e-8
     alpha = 3.90e-3
     T0 = 293.15
+
+[Al-7075]
+    description = """General 7075 characteristics and uses (from Alcoa): Very high strength material used for highly stressed structural parts. The T7351 temper offers improved stress-corrosion cracking resistance.
+                     Uses: Aircraft fittings, gears and shafts, fuse parts, meter shafts and gears, missile parts, regulating valve parts, worm gears, keys, aircraft, aerospace and defense applications."""
+
+    source = "https://www.matweb.com/search/DataSheet.aspx?MatGUID=6653b72914864cc0a0ff7adf5b720167"
+    density = 2810.0 #kg/m3
+    youngs_modulus = 72e9 #Pa
+    shear_modulus = 26.9e9 #Pa
+    poissons_ratio = 0.33
+    YTS = 338e6 #Yield tensile strength
+    UTS = 505e6  #Ultimate tensile strength
+    shear_strength = 300e6
 
 [Ti-6242]
     description = "Titanium 6242 alloy"

--- a/src/misc/materials.jl
+++ b/src/misc/materials.jl
@@ -1,6 +1,9 @@
 abstract type AbstractMaterials end
 
-MaterialProperties = TOML.parsefile("src/material_data/MaterialProperties.toml")
+using TOML, DocStringExtensions
+
+__abs_path_prefix__ = dirname(@__DIR__)
+MaterialProperties = TOML.parsefile(joinpath(__abs_path_prefix__,"material_data/MaterialProperties.toml"))
 
 """
 $TYPEDEF

--- a/src/misc/materials.jl
+++ b/src/misc/materials.jl
@@ -1,5 +1,3 @@
-abstract type AbstractMaterials end
-
 using TOML, DocStringExtensions
 
 __abs_path_prefix__ = dirname(@__DIR__)

--- a/src/misc/materials.jl
+++ b/src/misc/materials.jl
@@ -10,7 +10,7 @@ Generic structural alloy.
 
 $TYPEDFIELDS
 """
-struct StructuralAlloy <: AbstractMaterials
+struct StructuralAlloy
     """Density [kg/m³]"""
     ρ::Float64
     """Young's Modulus [Pa]"""
@@ -67,7 +67,7 @@ Generic conductor.
 
 $TYPEDFIELDS
 """
-@kwdef struct Conductor <: AbstractMaterials
+@kwdef struct Conductor 
     """Density [kg/m³]"""
     ρ::Float64
     """Resistivity [Ω⋅m]"""
@@ -117,7 +117,7 @@ Generic insulator.
 
 $TYPEDFIELDS
 """
-@kwdef struct Insulator <: AbstractMaterials
+@kwdef struct Insulator
     """Density [kg/m³]"""
     ρ::Float64
     """Dielectric strength [V/m]"""
@@ -172,13 +172,14 @@ function resistivity(cond::Conductor, T::Float64=293.15)
 end  # function resistivity
 
 """
-    create_dict(material::AbstractMaterials)
+    create_dict(material)
 
-Creates a dictionary from a given AbstractMaterials subtype
+Creates a dictionary from a given material type
 """
-function create_dict(material::AbstractMaterials)
+function create_material_dict(material)
     fn = fieldnames(typeof(material))
-    dict = Dict("Material" => Dict(fn .=> getproperty.([material], fn)))
+    isempty(fn) ? error("Not an appropriate sturct") :
+    Dict("Material" => Dict(fn .=> getproperty.([material], fn)))
 end
 
 """
@@ -195,5 +196,5 @@ function save_material_toml(filename::String, dict::AbstractDict)
     end
 end  # function save_material_toml
 
-save_material_toml(filename::String, material::AbstractMaterials) = 
-save_material_toml(filename, create_dict(material))
+save_material_toml(filename::String, material) = 
+save_material_toml(filename, create_material_dict(material))

--- a/src/utils/materials.jl
+++ b/src/utils/materials.jl
@@ -149,11 +149,6 @@ function Insulator(material::String)
     end
 
 end
-# struct SturctAlloy <: Metals
-#     UTS
-#     E
-#    < and so on... >
-# end
 
 """
     resxden(cond::conductor)

--- a/src/utils/materials.jl
+++ b/src/utils/materials.jl
@@ -5,6 +5,46 @@ abstract type Dielectrics <: AbstractMaterials end
 """
 $TYPEDEF
 
+Material properties covering a wide range of disciplines:
+
+$TYPEDFIELDS
+"""
+@kwdef struct MaterialProperties
+    # ---------------------
+    # Mass Properties
+    # ---------------------
+    """Density [kg/m³]"""
+    ρ::Float64
+    # ---------------------
+    # Structural Properties
+    # ---------------------
+    """Young's Modulus [Pa]"""
+    E::Float64
+    """Shear Modulus [Pa]"""
+    G::Float64
+    """Poisson's Ratio [-]"""
+    ν::Float64
+    """Maximum Stress [Pa] (Yield or Ultimate Strength)"""
+    σmax::Float64
+    """Maximum Shear [Pa]"""
+    τmax::Float64
+    # ---------------------
+    # Electric Properties
+    # ---------------------
+    """Resistivity [Ω⋅m]"""
+    resistivity::Float64
+    """Thermal coefficient of resitivity [K⁻¹]"""
+    α::Float64
+    """Temperature at base resistivity [K]"""
+    T0::Float64 = 293.15 # 20°C
+    """Dielectric strength [V/m]"""
+    Emax::Float64
+
+end
+
+"""
+$TYPEDEF
+
 Generic conductor.
 
 $TYPEDFIELDS

--- a/src/utils/materials.jl
+++ b/src/utils/materials.jl
@@ -67,6 +67,32 @@ $TYPEDFIELDS
     Emax::Float64
 end
 
+"""
+    insulator(material::String)
+
+Outer constructor for `insulator` types. 
+Material specified needs to have the following data in the database:
+- ρ (density): Density [kg/m³]
+- Emax (dielectric strength): Dielectric strength [V/m]
+"""
+function insulator(material::String)
+    local MatProp, ρ, Emax
+    try
+        MatProp = MaterialProperties[material]
+    catch
+        error("Cannot find $material in Material Properties database")
+    else
+        try
+            ρ = MatProp["density"]
+            Emax = MatProp["dielectric_strength"]
+        catch 
+            error("Insufficient data in database for $material to build an insulator")
+        else
+            insulator(ρ, Emax)
+        end
+    end
+
+end
 # struct SturctAlloy <: Metals
 #     UTS
 #     E
@@ -92,20 +118,6 @@ function resistivity(cond::conductor, T::Float64=293.15)
     ΔT = T - cond.T0
     return cond.resistivity*(1 + cond.α*ΔT)
 end  # function resistivity
-
-#-------------------------------------------------------------
-# Standard materials taken from here: https://en.wikipedia.org/wiki/Electrical_resistivity_and_conductivity#Resistivity_and_conductivity_of_various_materials
-const Al = aluminium = conductor(ρ = 2700.0, resistivity = 2.65e-8, α = 3.90e-3)
-const Cu = copper = conductor(ρ =  8960.0, resistivity = 1.68e-8, α = 4.04e-3)
-const Ag = silver = conductor(ρ = 10490.0, resistivity = 1.59e-8, α = 3.80e-3)
-const Au = gold   = conductor(ρ = 19300.0, resistivity = 2.44e-8, α = 3.40e-3)
-
-# Insulators
-const PTFE = insulator(ρ = 2150.0, Emax = 19.7e6)
-const PEEK = insulator(ρ = 1320.0, Emax = 23e6)
-const polyimide = insulator(ρ = 1700, Emax = 10e6) # Dowdle et al https://doi.org/10.2514/6.2018-5026
-
-
 
 """
     create_dict(material::AbstractMaterials)

--- a/src/utils/materials.jl
+++ b/src/utils/materials.jl
@@ -1,8 +1,6 @@
 abstract type AbstractMaterials end
-abstract type Metals <: AbstractMaterials end
-abstract type Dielectrics <: AbstractMaterials end
 
-MatProp = TOML.parsefile("src/material_data/MaterialProperties.toml")
+MaterialProperties = TOML.parsefile("src/material_data/MaterialProperties.toml")
 
 
 """
@@ -12,7 +10,7 @@ Generic conductor.
 
 $TYPEDFIELDS
 """
-@kwdef struct conductor <: Metals
+@kwdef struct conductor <: AbstractMaterials
     """Density [kg/m³]"""
     ρ::Float64
     """Resistivity [Ω⋅m]"""
@@ -35,17 +33,17 @@ Material specified needs to have the following data in the database:
 - T0: Temperature at base resistivity [K]
 """
 function conductor(material::String)
-    local dict, ρ, resistivity, α, T0
+    local MatProp, ρ, resistivity, α, T0
     try
-        dict = MatProp[material]
+        MatProp = MaterialProperties[material]
     catch
         error("Cannot find $material in Material Properties database")
     else
         try
-            ρ = dict["density"]
-            resistivity = dict["resistivity"]
-            α = dict["alpha"]
-            T0 = dict["T0"]
+            ρ = MatProp["density"]
+            resistivity = MatProp["resistivity"]
+            α = MatProp["alpha"]
+            T0 = MatProp["T0"]
         catch 
             error("Insufficient data in database for $material to build a conductor")
         else
@@ -62,7 +60,7 @@ Generic insulator.
 
 $TYPEDFIELDS
 """
-@kwdef struct insulator <: Dielectrics
+@kwdef struct insulator <: AbstractMaterials
     """Density [kg/m³]"""
     ρ::Float64
     """Dielectric strength [V/m]"""

--- a/src/utils/materials.jl
+++ b/src/utils/materials.jl
@@ -1,0 +1,92 @@
+abstract type AbstractMaterials end
+abstract type Metals <: AbstractMaterials end
+abstract type Dielectrics <: AbstractMaterials end
+
+"""
+$TYPEDEF
+
+Generic conductor.
+
+$TYPEDFIELDS
+"""
+@kwdef struct conductor <: Metals
+    """Density [kg/m³]"""
+    ρ::Float64
+    """Resistivity [Ω⋅m]"""
+    resistivity::Float64
+    """Thermal coefficient of resitivity [K⁻¹]"""
+    α::Float64
+    """Temperature at base resistivity [K]"""
+    T0::Float64 = 293.15 # 20°C
+end
+
+
+
+
+function conductor(dict::AbstractDict)
+    ρ = dict["ρ"]
+    resistivity = dict["resistivity"]
+    α = dict["α"]
+    T0 = dict["T0"]
+    conductor(ρ, resistivity, α, T0)
+end
+
+"""
+$TYPEDEF
+
+Generic insulator.
+
+$TYPEDFIELDS
+"""
+@kwdef struct insulator <: Dielectrics
+    """Density [kg/m³]"""
+    ρ::Float64
+    """Dielectric strength [V/m]"""
+    Emax::Float64
+end
+
+# struct SturctAlloy <: Metals
+#     UTS
+#     E
+#    < and so on... >
+# end
+
+"""
+    resxden(cond::conductor)
+
+Returns the resisitivity-density product in kg⋅Ω/m²
+"""
+function resxden(cond::conductor)
+    return cond.resistivity*cond.ρ
+end
+
+"""
+    resistivity(cond::conductor, T::Float64)
+
+Returns the resistivity of the conductor at the given temperature. Defaults to 
+T = 293.15 K = 20°C
+"""
+function resistivity(cond::conductor, T::Float64=293.15)
+    ΔT = T - cond.T0
+    return cond.resistivity*(1 + cond.α*ΔT)
+end  # function resistivity
+
+#-------------------------------------------------------------
+# Standard materials taken from here: https://en.wikipedia.org/wiki/Electrical_resistivity_and_conductivity#Resistivity_and_conductivity_of_various_materials
+const Al = aluminium = conductor(ρ = 2700.0, resistivity = 2.65e-8, α = 3.90e-3)
+const Cu = copper = conductor(ρ =  8960.0, resistivity = 1.68e-8, α = 4.04e-3)
+const Ag = silver = conductor(ρ = 10490.0, resistivity = 1.59e-8, α = 3.80e-3)
+const Au = gold   = conductor(ρ = 19300.0, resistivity = 2.44e-8, α = 3.40e-3)
+
+# Insulators
+const PTFE = insulator(ρ = 2150.0, Emax = 19.7e6)
+const PEEK = insulator(ρ = 1320.0, Emax = 23e6)
+const polyimide = insulator(ρ = 1700, Emax = 10e6) # Dowdle et al https://doi.org/10.2514/6.2018-5026
+
+
+
+function create_dict(material::AbstractMaterials)
+    fn = fieldnames(typeof(material))
+    dict = Dict(typeof(material) => Dict(fn .=> getproperty.([material], fn)))
+end
+

--- a/src/utils/materials.jl
+++ b/src/utils/materials.jl
@@ -4,45 +4,6 @@ abstract type Dielectrics <: AbstractMaterials end
 
 MatProp = TOML.parsefile("src/material_data/MaterialProperties.toml")
 
-"""
-$TYPEDEF
-
-Material properties covering a wide range of disciplines:
-
-$TYPEDFIELDS
-"""
-@kwdef struct MaterialProperties
-    # ---------------------
-    # Mass Properties
-    # ---------------------
-    """Density [kg/m³]"""
-    ρ::Float64
-    # ---------------------
-    # Structural Properties
-    # ---------------------
-    """Young's Modulus [Pa]"""
-    E::Float64
-    """Shear Modulus [Pa]"""
-    G::Float64
-    """Poisson's Ratio [-]"""
-    ν::Float64
-    """Maximum Stress [Pa] (Yield or Ultimate Strength)"""
-    σmax::Float64
-    """Maximum Shear [Pa]"""
-    τmax::Float64
-    # ---------------------
-    # Electric Properties
-    # ---------------------
-    """Resistivity [Ω⋅m]"""
-    resistivity::Float64
-    """Thermal coefficient of resitivity [K⁻¹]"""
-    α::Float64
-    """Temperature at base resistivity [K]"""
-    T0::Float64 = 293.15 # 20°C
-    """Dielectric strength [V/m]"""
-    Emax::Float64
-
-end
 
 """
 $TYPEDEF
@@ -63,23 +24,35 @@ $TYPEDFIELDS
 end
 
 
+"""
+    conductor(material::String)
+
+Outer constructor for `conductor` types. 
+Material specified needs to have the following data in the database:
+- ρ (density): Density [kg/m³]
+- resistivity: Resistivity [Ω⋅m]
+- α (alpha: Thermal coefficient of resisitivity [K⁻¹]
+- T0: Temperature at base resistivity [K]
+"""
 function conductor(material::String)
     local dict, ρ, resistivity, α, T0
     try
         dict = MatProp[material]
     catch
         error("Cannot find $material in Material Properties database")
+    else
+        try
+            ρ = dict["density"]
+            resistivity = dict["resistivity"]
+            α = dict["alpha"]
+            T0 = dict["T0"]
+        catch 
+            error("Insufficient data in database for $material to build a conductor")
+        else
+            conductor(ρ, resistivity, α, T0)
+        end
     end
 
-    try
-        ρ = dict["density"]
-        resistivity = dict["resistivity"]
-        α = dict["alpha"]
-        T0 = dict["T0"]
-    catch 
-        error("Insufficient data in database for $material to build a conductor")
-    end
-    conductor(ρ, resistivity, α, T0)
 end
 
 """

--- a/src/utils/materials.jl
+++ b/src/utils/materials.jl
@@ -25,7 +25,7 @@ struct StructuralAlloy <: AbstractMaterials
 end
 
 """
-    StructuralAlloy(material::String)
+    StructuralAlloy(material::String; max_avg_stress = 1.1, safety_factor = 1.0)
 
 Outer constructor for `StructuralAlloy` types. 
 Material specified needs to have the following data in the database:
@@ -36,7 +36,7 @@ Material specified needs to have the following data in the database:
 - σmax: Maximum Stress (Yield or Ultimate Strength) [Pa]
 - τmax: Maximum Shear [Pa]
 """
-function StructuralAlloy(material::String)
+function StructuralAlloy(material::String; max_avg_stress = 1.1, safety_factor = 1.5)
     local MatProp, ρ, E, G, ν, σmax, τmax
     try
         MatProp = MaterialProperties[material]
@@ -48,8 +48,8 @@ function StructuralAlloy(material::String)
             E    = MatProp["youngs_modulus"]
             G    = MatProp["shear_modulus"]
             ν    = MatProp["poissons_ratio"]
-            σmax = MatProp["YTS"]
-            τmax = MatProp["shear_strength"]
+            σmax = MatProp["YTS"]/max_avg_stress/safety_factor
+            τmax = MatProp["shear_strength"]/max_avg_stress/safety_factor
         catch 
             error("Insufficient data in database for $material to build a StructuralAlloy")
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using Test
     include("regression_test_wsize.jl")
     include("unit_test_heat_exchanger.jl")
     include("unit_test_PEMFC.jl")
+    include("unit_test_materials.jl")
     include("unit_test_fueltank.jl")
     include("unit_test_outputs.jl")
 end

--- a/test/unit_test_materials.jl
+++ b/test/unit_test_materials.jl
@@ -1,0 +1,34 @@
+@testset "Materials" verbose=true begin
+    database = TASOPT.MaterialProperties
+    @testset "Structural Alloys" begin
+        Al7075 = StructuralAlloy("Al-7075")
+        @test Al7075.ρ == database["Al-7075"]["density"]
+        @test Al7075.E == database["Al-7075"]["youngs_modulus"]
+        #Check that safety_factors are being applied
+        @test Al7075.σmax == database["Al-7075"]["YTS"]/1.1/1.5 
+        Al = StructuralAlloy("Al-7075"; max_avg_stress = 1.0, safety_factor = 2.0)
+        @test Al.σmax == database["Al-7075"]["YTS"]/1.0/2.0
+        @test Al.τmax == database["Al-7075"]["shear_strength"]/1.0/2.0
+    end
+
+    @testset "Conductors" begin
+        Cu = Conductor("Cu")
+        @test Cu.ρ == database["Cu"]["density"] 
+        @test TASOPT.resxden(Cu) == 0.000150528
+        @test TASOPT.resistivity(Cu) == database["Cu"]["resistivity"]
+        @test TASOPT.resistivity(Cu, 300.0) ≈ 1.7264923200000005e-8
+    end
+
+    @testset "Insulators" begin
+        PTFE = Insulator("PTFE")
+        @test PTFE.ρ == database["PTFE"]["density"]
+    end
+    
+    # Test that unreasonable requests throw errors
+    ## Try making something structural with gold
+    @testset "Material errors" begin
+        @test_throws ErrorException StructuralAlloy("Ag")
+        @test_throws ErrorException Conductor("PTFE")
+        @test_throws ErrorException Insulator("Cu")
+    end
+end

--- a/test/unit_test_materials.jl
+++ b/test/unit_test_materials.jl
@@ -25,8 +25,13 @@
     end
     
     # Test that unreasonable requests throw errors
-    ## Try making something structural with gold
+    ## Try making something structural with silver, a conductor using
+    ## insulator properties or an insulator using conductor properties.
     @testset "Material errors" begin
+        @test_throws ErrorException StructuralAlloy("unobtanium")
+        @test_throws ErrorException Conductor("unobtanium")
+        @test_throws ErrorException Insulator("unobtanium")
+
         @test_throws ErrorException StructuralAlloy("Ag")
         @test_throws ErrorException Conductor("PTFE")
         @test_throws ErrorException Insulator("Cu")


### PR DESCRIPTION
Chipping away at a more modular and cleaner code. This PR adds the ability to choose from some standard aerospace materials when designing an aircraft in TASOPT. 

Users can add materials of their choice to the `MaterialProperties.toml` database file. 

When creating components in TASOPT checks are performed if the properties provided in the database are sufficient to create a component that uses the material specified in that fashion. E.g., creating a component of type `StructuralAlloy` will only work if properties such as the density, elastic modulus, yield strength etc are provided. Similarly component of type `Conductor` can only be created if the database contains properties about the material's resistivity. 