### PR TITLE
File/module structure tweaks

### DIFF
--- a/docs/src/examples/payload_range.md
+++ b/docs/src/examples/payload_range.md
@@ -29,11 +29,11 @@ using TASOPT
 # you can optionally define
 # const tas = TASOPT 
 # to use as a shorthand
-include(joinpath(TASOPT.__TASOPTroot__, "./src/misc/index.inc"))
+include(__TASOPTindices__)
 # import indices for calling parameters
 
 # Load aircraft using default module
-ac = TASOPT.read_aircraft_model(joinpath(TASOPT.__TASOPTroot__, "../example/PRD_input.toml"))
+ac = TASOPT.read_aircraft_model(joinpath(__TASOPTroot__, "../example/PRD_input.toml"))
 time_wsize = @elapsed size_aircraft!(ac)
 ```
 

--- a/example/example_PRD.jl
+++ b/example/example_PRD.jl
@@ -9,7 +9,7 @@ using TASOPT
 # you can optionally define
 # const tas = TASOPT 
 # to use as a shorthand
-include("../src/misc/index.inc")
+include(__TASOPTindices__)
 # import indices for calling parameters
 
 function PayloadRange(ac; Rpts = 20, Ppts = 20, filename = "PayloadRangeDiagram.png", OEW = false)

--- a/example/example_opt.jl
+++ b/example/example_opt.jl
@@ -5,7 +5,7 @@ using Printf
 # you can optionally define
 # const tas = TASOPT 
 # to use as a shorthand
-include("../src/misc/index.inc")
+include(__TASOPTindices__)
 # import indices for calling ac.parameters
 using NLopt
 

--- a/src/IO/read_input.jl
+++ b/src/IO/read_input.jl
@@ -1,9 +1,6 @@
 using TOML
 export read_aircraft_model, load_default_model
 
-include(joinpath(__TASOPTroot__,"IO/size_cabin.jl"))
-include(joinpath(__TASOPTroot__,"fuel/fuel_properties.jl"))
-
 """
     read_input(k::String, dict::AbstractDict=data, 
     default_dict::AbstractDict = default)

--- a/src/IO/read_input.jl
+++ b/src/IO/read_input.jl
@@ -1,9 +1,8 @@
 using TOML
 export read_aircraft_model, load_default_model
 
-include("size_cabin.jl")
-include("../fuel/fuel_properties.jl")
-#using ..structures
+include(joinpath(__TASOPTroot__,"IO/size_cabin.jl"))
+include(joinpath(__TASOPTroot__,"fuel/fuel_properties.jl"))
 
 """
     read_input(k::String, dict::AbstractDict=data, 

--- a/src/IO/size_cabin.jl
+++ b/src/IO/size_cabin.jl
@@ -1,3 +1,4 @@
+export place_cabin_seats, arrange_seats
 """
     place_cabin_seats(pax, Rfuse)
 

--- a/src/TASOPT.jl
+++ b/src/TASOPT.jl
@@ -61,6 +61,7 @@ include(joinpath(__TASOPTroot__,"mission/LTO.jl"))
 include(joinpath(__TASOPTroot__,"mission/AircraftDeck.jl"))
 
 include(joinpath(__TASOPTroot__,"fuel/hydrogen.jl"))
+include(joinpath(__TASOPTroot__,"fuel/fuel_properties.jl"))
 include(joinpath(__TASOPTroot__,"engine/PT.inc"))
 
 # Input and output functions
@@ -76,6 +77,10 @@ include(joinpath(__TASOPTroot__,"IO/output_csv.jl"))
 include(joinpath(__TASOPTroot__,"cost/cost_est.jl"))
 include(joinpath(__TASOPTroot__,"cost/cost_val.jl"))
 include(joinpath(__TASOPTroot__,"utils/printBADA.jl"))
+
+#functionalities to be categorized: #TODO
+include(joinpath(__TASOPTroot__,"IO/size_cabin.jl"))
+
 
 export size_aircraft!
 

--- a/src/TASOPT.jl
+++ b/src/TASOPT.jl
@@ -19,23 +19,26 @@ using ForwardDiff
 using CSV, Tables
 using DocStringExtensions
 
+#convenient directories
 const __TASOPTroot__ = @__DIR__
+const __TASOPTindices__ = joinpath(__TASOPTroot__,"misc/index.inc") #include(__TASOPTindices__) in REPL
+export __TASOPTroot__, __TASOPTindices__
 
 # Constants and array indices
-include("./misc/constants.jl")
+include(joinpath(__TASOPTroot__,"misc/constants.jl"))
 export ft_to_m, in_to_m, nmi_to_m, deg_to_rad, 
        lbf_to_N, kts_to_mps, hp_to_W, lb_N
 export gee, gamSL, cpSL, μAir, pref, Tref
 
-include("./misc/units.jl")
+include(joinpath(__TASOPTroot__,"misc/units.jl"))
 export convertMass, convertForce, convertDist, 
        convertSpeed, convertPower, convertAngle
 
-include("./misc/materials.jl")
+include(joinpath(__TASOPTroot__,"misc/materials.jl"))
 export StructuralAlloy, Conductor, Insulator
 
-include("./misc/index.inc")
-include("./misc/aircraft.jl")
+include(__TASOPTindices__)
+include(joinpath(__TASOPTroot__,"misc/aircraft.jl"))
 export aircraft, fuselage_tank
 
 #Load modules

--- a/src/aero/aero.jl
+++ b/src/aero/aero.jl
@@ -7,13 +7,13 @@ module aerodynamics
 
 using StaticArrays
 using ..atmosphere
+import ..TASOPT: __TASOPTindices__, __TASOPTroot__
 
 export airfoil, cdsum!, surfcm, wingsc, wingpo, wingcl, fusebl!
 
 #include index to access arrays
-include("../misc/index.inc")
-
-include("../utils/spline.jl")
+include(__TASOPTindices__)
+include(joinpath(__TASOPTroot__,"utils/spline.jl"))
 
 idim::Int = 360
 jdim::Int = 360

--- a/src/aero/aero.jl
+++ b/src/aero/aero.jl
@@ -38,11 +38,8 @@ include("airfoil.jl")
 include("airtable.jl")
 include("airfun.jl")
 
-__abs_path_prefix__ = dirname(@__DIR__)
-airfoil_data = joinpath(__abs_path_prefix__,"airfoil_data/C.air")
-
+airfoil_data = joinpath(__TASOPTroot__,"airfoil_data/C.air")
 airsection = airtable(airfoil_data);
-
 
 include("surfcd.jl")
 include("surfcm.jl")

--- a/src/engine/engine.jl
+++ b/src/engine/engine.jl
@@ -13,9 +13,10 @@ export tfweight, ddct, ddat, gct, gat, tfsize!, Ncmap, ecmap, Ncmap1, ecmap1, et
 export gassum, gassumd, gas_prat, gas_delh, gas_delhd, gas_burn, gas_burnd, gas_mach, gas_machd, gas_mass, gasfuel, gasPr
 export hxdesign!, hxweight
 
+import ..TASOPT: __TASOPTindices__, __TASOPTroot__
 
-include("../misc/index.inc")
-include("../misc/constants.jl")
+include(__TASOPTindices__)
+include(joinpath(__TASOPTroot__,"misc/constants.jl"))
 include("gasfun.jl")
 include("gascalc.jl")
 # include("tfan.jl")

--- a/src/engine/test/test.jl
+++ b/src/engine/test/test.jl
@@ -1156,9 +1156,6 @@ end
 
 @testset "tfcalc.jl" begin
 
-    # include("../index.inc")
-    # include("../constants.inc")
-
     pari = [24, 1, 1, 1, 1, 0, 0, 1, 1, 2]
     parg = readdlm("../data/parg.txt")
     pare = readdlm("../data/pare.txt")

--- a/src/fuel/fuel_properties.jl
+++ b/src/fuel/fuel_properties.jl
@@ -1,3 +1,5 @@
+export cryo_fuel_properties
+
 """
     cryo_fuel_properties(fuel::String, p::Float64)
 

--- a/src/misc/materials.jl
+++ b/src/misc/materials.jl
@@ -1,7 +1,7 @@
 using TOML, DocStringExtensions
 
-__abs_path_prefix__ = dirname(@__DIR__)
-MaterialProperties = TOML.parsefile(joinpath(__abs_path_prefix__,"material_data/MaterialProperties.toml"))
+filepath = joinpath(__TASOPTroot__,"material_data/MaterialProperties.toml")
+MaterialProperties = TOML.parsefile(filepath)
 
 """
 $TYPEDEF

--- a/src/propsys/propsys.jl
+++ b/src/propsys/propsys.jl
@@ -6,9 +6,10 @@ Will cover alternate engine models - NPSS vs Drela's orig. model vs pyCycle
 module propsys
 
 export NPSS_run, startNPSS, endNPSS
+import ..TASOPT: __TASOPTindices__, __TASOPTroot__
 
-include("../misc/index.inc")
-include("../misc/constants.jl")
+include(__TASOPTindices__)
+include(joinpath(__TASOPTroot__,"misc/constants.jl"))
 
 include("NPSS_functions.jl")
 

--- a/src/structures/structures.jl
+++ b/src/structures/structures.jl
@@ -10,11 +10,12 @@ using ..atmosphere
 using NLsolve
 using Roots
 using NLopt
+import ..TASOPT: __TASOPTindices__, __TASOPTroot__
 
 export surfw, surfdx, fusew, tailpo, tanksize!, update_fuse!, update_fuse_for_pax!
 
-include("../misc/index.inc")
-include("../misc/constants.jl")
+include(__TASOPTindices__)
+include(joinpath(__TASOPTroot__,"misc/constants.jl"))
 #include fuselage sizing
 include("fuseW.jl")
 

--- a/src/structures/update_fuse.jl
+++ b/src/structures/update_fuse.jl
@@ -1,5 +1,4 @@
-include("../IO/size_cabin.jl")
-
+export update_fuse!, update_fuse_for_pax!
 """
     update_fuse!(pari, parg)
 

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -1,10 +1,12 @@
 
 using Pkg, Dates
+import ..TASOPT: __TASOPTindices__
+
 println(today())
 println("Current location $(pwd())")
 using TASOPT
 const aerodynamics = TASOPT.aerodynamics
-include("../src/misc/index.inc")
+include(__TASOPTindices__)
 nmisx = 1
 pari = zeros(Int64, iitotal)
 parg = zeros(Float64, igtotal)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,8 @@ using Test
     include("unit_test_outputs.jl")
     include("unit_test_io.jl")
 
+    #engine tests housed in /src/engine/test/
+    # neglected for a while, should probs include, though some break rn
+    # include(joinpath(__TASOPTroot__, "engine/test/test.jl"))
+
 end


### PR DESCRIPTION
- added convenience path vars: `__TASOPTroot__` (goes to /src) and `__TASOPTindices__` (goes to /src/misc/index.inc) for robust and consistent `include`
- corrected stylistically-meh include's in cabin sizing considerations and fuels. added exports to compensate
- made note about missing engine tests