### PR TITLE
Replacing enthalpy of combustion in PFEI by LHV

### DIFF
--- a/src/engine/engine.jl
+++ b/src/engine/engine.jl
@@ -10,7 +10,7 @@ using LinearAlgebra
 
 export tfcalc!, mcool, Tmcalc, gas_tset, gaschem
 export tfweight, ddct, ddat, gct, gat, tfsize!, Ncmap, ecmap, Ncmap1, ecmap1, etmap, Pimap, tfoper!
-export gassum, gassumd, gas_prat, gas_delh, gas_delhd, gas_burn, gas_burnd, gas_mach, gas_machd, gas_mass, gasfuel, gasPr
+export gassum, gassumd, gas_prat, gas_delh, gas_delhd, gas_burn, gas_burnd, gas_mach, gas_machd, gas_mass, gasfuel, fuelLHV, gasPr
 export hxdesign!, hxweight
 
 import ..TASOPT: __TASOPTindices__, __TASOPTroot__

--- a/src/misc/index.inc
+++ b/src/misc/index.inc
@@ -56,7 +56,8 @@
       imfexcdt   = 32
       imfexcdf   = 33
       imDeltaTatm= 34
-      imtotal    = 34
+      imLHVfuel  = 35
+      imtotal    = 35
 
 #---- indices for geometry (airframe) variables and other sizing variables
       const igFOpt     =   1

--- a/src/mission/mission.jl
+++ b/src/mission/mission.jl
@@ -835,9 +835,7 @@ function mission!(pari, parg, parm, para, pare, Ldebug)#, iairf, initeng, ipc1)
 
       # mission PFEI
       Wburn = WMTO * fburn
-      parm[imPFEI] = Wburn/gee * pare[iehfuel, ipcruise1] / (parm[imWpay] * parm[imRange])
-
-
+      parm[imPFEI] = Wburn/gee * parm[imLHVfuel] / (parm[imWpay] * parm[imRange])
 
       return t_prop
 end

--- a/src/sizing/wsize.jl
+++ b/src/sizing/wsize.jl
@@ -106,6 +106,9 @@ function wsize(ac; itermax=35,
     para[iaDAfwake, :] .= DAfwake
     para[iaPAfinf, :] .= PAfinf
 
+    #Calculate fuel lower heating value for PFEI
+    parm[imLHVfuel] = fuelLHV(ifuel)
+
     # Set quantities that are fixed during weight iteration
 
     # Unpack payload and range for design mission - this is the mission that the structures are sized for

--- a/test/regression_test_wsize.jl
+++ b/test/regression_test_wsize.jl
@@ -28,7 +28,7 @@
         end
     end
     
-    @test ac.parm[imPFEI] ≈  0.8830896229083405
+    @test ac.parm[imPFEI] ≈  0.919121257897844
 
 end
 
@@ -61,7 +61,7 @@ end
         end
     end
     
-    @test ac.parm[imPFEI] ≈ 1.1181717704710181
+    @test ac.parm[imPFEI] ≈ 1.1642157697355595
 
 end
 
@@ -94,6 +94,6 @@ end
         end
     end
     
-    @test ac.parm[imPFEI] ≈ 0.7868090108559759
+    @test ac.parm[imPFEI] ≈ 0.8107247842565991
 
 end


### PR DESCRIPTION
This PR makes a change to the way PFEI is calculated. Rather than using the enthalpy of combustion of the fuel, which depends on the fuel initial temperature, the PFEI is now calculated with the lower heating value, which is a constant for a given fuel type.