### PR TITLE
Heat exchangers: small bug fix in turbine cooling

### DIFF
--- a/src/engine/tfoper.jl
+++ b/src/engine/tfoper.jl
@@ -907,9 +907,16 @@ function tfoper!(gee, M0, T0, p0, a0, Tref, pref,
                   Trr_Tb = Trr_gmi4 * (gmi4_Rt4 * Rt4_Tb + gmi4_cpt4 * cpt4_Tb)
 
                   if (icool == 1)
+                        # Heat exchanger to cool turbine cooling air
+                        ht_tc = ht3 + Δh_TurbC #Specific enthalpy of turbine cooling air
+                        Tt_tc, Tttc_httc, _ = gas_tsetd(alpha, nair, ht_tc, Tt3) #Temperature of turbine cooling air
+
+                        httc_ht3 = 1.0
+                        Tttc_Tt3 = Tttc_httc * httc_ht3 / Tt3_ht3
+
                         #------ epsrow(.) is assumed to be passed in.. calculate Tmrow(.)
                         Tmrow_copy = Tmcalc(ncrowx, ncrow,
-                              Tt3, Tb, dTstrk, Trrat,
+                              Tt_tc, Tb, dTstrk, Trrat,
                               efilm, tfilm, StA, epsrow)
                         Tmrow[:] = Tmrow_copy[:]
 
@@ -927,13 +934,6 @@ function tfoper!(gee, M0, T0, p0, a0, Tref, pref,
                         fc_mh = 0.0
                         fc_Tb = 0.0
                         fc_Mi = fc_fo * fo_Mi
-
-                        # Heat exchanger to cool turbine cooling air
-                        ht_tc = ht3 + Δh_TurbC #Specific enthalpy of turbine cooling air
-                        Tt_tc, Tttc_httc, _ = gas_tsetd(alpha, nair, ht_tc, Tt3) #Temperature of turbine cooling air
-
-                        httc_ht3 = 1.0
-                        Tttc_Tt3 = Tttc_httc * httc_ht3 / Tt3_ht3
 
                   else
                         # Heat exchanger to cool turbine cooling air

--- a/src/engine/tfoper.jl
+++ b/src/engine/tfoper.jl
@@ -906,14 +906,14 @@ function tfoper!(gee, M0, T0, p0, a0, Tref, pref,
                   Trr_mh = Trr_gmi4 * (gmi4_Rt4 * Rt4_mh + gmi4_cpt4 * cpt4_mh)
                   Trr_Tb = Trr_gmi4 * (gmi4_Rt4 * Rt4_Tb + gmi4_cpt4 * cpt4_Tb)
 
+                  # Heat exchanger to cool turbine cooling air
+                  ht_tc = ht3 + Δh_TurbC #Specific enthalpy of turbine cooling air
+                  Tt_tc, Tttc_httc, _ = gas_tsetd(alpha, nair, ht_tc, Tt3) #Temperature of turbine cooling air
+
+                  httc_ht3 = 1.0
+                  Tttc_Tt3 = Tttc_httc * httc_ht3 / Tt3_ht3
+
                   if (icool == 1)
-                        # Heat exchanger to cool turbine cooling air
-                        ht_tc = ht3 + Δh_TurbC #Specific enthalpy of turbine cooling air
-                        Tt_tc, Tttc_httc, _ = gas_tsetd(alpha, nair, ht_tc, Tt3) #Temperature of turbine cooling air
-
-                        httc_ht3 = 1.0
-                        Tttc_Tt3 = Tttc_httc * httc_ht3 / Tt3_ht3
-
                         #------ epsrow(.) is assumed to be passed in.. calculate Tmrow(.)
                         Tmrow_copy = Tmcalc(ncrowx, ncrow,
                               Tt_tc, Tb, dTstrk, Trrat,
@@ -936,13 +936,6 @@ function tfoper!(gee, M0, T0, p0, a0, Tref, pref,
                         fc_Mi = fc_fo * fo_Mi
 
                   else
-                        # Heat exchanger to cool turbine cooling air
-                        ht_tc = ht3 + Δh_TurbC #Specific enthalpy of turbine cooling air
-                        Tt_tc, Tttc_httc, _ = gas_tsetd(alpha, nair, ht_tc, Tt3) #Temperature of turbine cooling air
-
-                        httc_ht3 = 1.0
-                        Tttc_Tt3 = Tttc_httc * httc_ht3 / Tt3_ht3
-
                         #------ calculate cooling mass flow ratios epsrow(.) to get specified Tmrow(.)
                         ncrow, epsrow_copy, epsrow_Tttc, epsrow_Tb, epsrow_Trr = mcool(ncrowx,
                               Tmrow, Tt_tc, Tb, dTstrk, Trrat,


### PR DESCRIPTION
This PR fixes a small bug in the blade metal temperature calculation when turbine cooling heat exchangers are used. The previous version ignored the effect of the heat exchanger when calculating the metal temperature for a given cooling fraction. The effect was accounted for later, so this issue only affected the metal temperature output and not the engine performance.