### PR TITLE
Reduced Input TASOPT

### DIFF
--- a/src/IO/default_regional.toml
+++ b/src/IO/default_regional.toml
@@ -1,16 +1,12 @@
-# This is a template TOML input file and are the default values that will
-# be used by TASOPT
 ["Aircraft Description"]
-    name = "Default TASOPT Model"
+    name = "Regional Aircraft TASOPT Model"
     description = """
-    This model file describes a basic single-aisle aircraft to 
-    demonstrate how to define a model file. The contents of this file are 
-    also loaded by the `TASOPT.jl` package as default if no other details are 
-    provided by the user.
+    This model file describes a basic single-aisle regional aircraft.
     """
-    aircraft_type   = "Narrow Body"     # 0: Regional Aircraft
-                                    # 1: Narrow Body Aircraft
-                                    # 2: Wide Body Aircraft
+    aircraft_type   = "Regional Aircraft"   # 0: Regional Aircraft
+                                        # 1: Narrow Body Aircraft
+                                        # 2: Wide Body Aircraft
+
 
 #-------------------------------------------------#
 ##               Note on units                   ##
@@ -49,7 +45,7 @@
     prop_sys_arch = "TF" #Options are TF: Turbofan
                          #            TE: Turbo-electric
 [Fuel]
-    fuel_type       = "Jet-A" # Choices are "Jet-A", "LH2" and "CH4"
+    fuel_type       = "Jet-A" # Choices are ... [TODO]
     fuel_in_wing    = true # Is fuel stored in wings?
     fuel_in_wingcen = true # Is fuel stored in wing center box?
     fuel_usability_factor = 0.90 # fraction of max fuel volume that is usable
@@ -57,66 +53,31 @@
     fuel_temp = 280.0
     fuel_density = 817.0 #kg/m3
 
-[Fuel.Storage] #Default fuselage fuel storage parameters for cryogenic fuels
-    tank_placement = "rear" #Location of tank in fuselage. Choices are "front", "rear", or "both".
-
-    tank_aspect_ratio = 2.0
-    fuselage_clearance = "0.3 ft"
-    additional_mass_fraction = 0.25
-    weld_efficiency = 0.9 
-    ullage_fraction = 0.05 #minimum ullage fraction at tank venting pressure
-    heat_leak_factor = 1.3 #Factor to account for heat leakage through structural elements, piping, etc (qfac > 1)
-    SL_temperature_for_tank = "288.2 K"
-
-    #Tank pressure design parameters
-    pressure_rise_factor = 2.0 #Factor to account for stratification in homogenous tank model (pfac >= 1)
-    pressure_venting = "2 atm"
-    pressure_initial = "1.2 atm"
-    hold_departure = "0 h"
-    hold_arrival = "0 h"
-
-    inner_vessel_material = "Al-2219-T87"
-    inner_vessel_support_angle = "80 deg"
-    
-    #Insulation options: "rohacell41S", "polyurethane27", "polyurethane32", "polyurethane35", "vacuum", "mylar", "microspheres"
-    size_insulation = true #Flag to decide whether to size insulation for boiloff
-    insulation_material = ["polyurethane32", "polyurethane32", "polyurethane32"] 
-    insulation_segment_base_thickness = [0.05, 0.05, 0.05] #m
-    
-    cruise_boiloff_rate = 0.4 #%/hour, used if size_insulation == true
-    insulation_thicknesses_design_indices = [1,2,3] #insulation segments to size if size_insulation == true
-
-    #Parameters for double-walled tank, if "vacuum" is in insulation_material
-    outer_vessel_material = "Al-2219-T87"
-    outer_vessel_support_angles = ["45 deg", "135 deg"]
-    
 [Mission]
-    N_missions = 2 # Number of missions to be modeled (first mission is the design mission)
-    max_pax = 230               # Maximum number of passengers for aircarft
+    N_missions = 1 # Number of missions to be modeled (first mission is the design mission)
+    pax = 118       # Number of passengers in each mission
+    max_pax = 122               # Maximum number of passengers for aircarft 
                                 # defines the maximum payload carrying capacity of the aircraft
-                                
-    range = ["3000.0 nmi", "2000.0 nmi"] # Design Range + second mission range
+    
+    range = "2200.0 nmi"
+    # Design Range + second mission range           
+    weight_per_pax = "215.0 lbf" # Specify weight per passenger - 
+                            # includes luggage [lbm or lbf or kg or N] 
+                            # judging you if you use imperial units but wtvs
 
-    pax = [180, 150]                    # Number of passengers in each mission
-                                        # weight per pax also specified (215 lbf/pax is std)
-
-    weight_per_pax = "215.0 lbf"    # Specify weight per passenger - 
-                                    # includes luggage [lbm or lbf or kg or N] 
-                                    # judging you if you use imperial units but wtvs
-
-    fuel_reserves = 0.20 # W_reserveFuel / W_fuelburned
+    fuel_reserves = 0.05 # W_reserveFuel / W_fuelburned
 
     Nlift = 3.0 # Max vertical load factor for wing bending loads
-    Vne = "280 kts" # Never exceed IAS for tail loads
+    Vne = "280 kts" # Never exceed ac for tail loads
 
 [Mission.Takeoff]
-    takeoff_alt = ["0.0 ft", "500 ft"] 
-    takeoff_T = [288.2, 298.0]
+    takeoff_alt = "0 ft"
+    takeoff_T = 288.2
 
-    max_balanced_field_length = "8000.0 ft"
+    max_balanced_field_length = "7450.0 ft"
     Nland = 6.0 # Max vertical load factor for fuse bending loads
 
-    CL_max_perp     = 2.25  #CLmax/(cos(sweep))^2
+    CL_max_perp     = 2.0  #CLmax/(cos(sweep))^2
     CD_dead_engine  = 0.50  #CDA_fan/ A_fan
     CD_landing_gear = 0.015 #CD*Agear/ Sref
     CD_spoilers     = 0.10  #CD*Aspoiler/ Sref
@@ -130,12 +91,12 @@
     minimum_top-of-climb_gradient = 0.015
 
 [Mission.Cruise]
-    cruise_alt  = ["35000.0 ft", "30e3 ft"]
+    cruise_alt  = "38500 ft"
     cruise_mach = 0.80
-    cruise_CL   = 0.57
+    cruise_CL   = 0.52
 
 [Mission.Descent]
-    descent_angle_top-of-descent = "-3.0 deg"
+    descent_angle_top-of-descent = "-2.5 deg"
     descent_angle_bottom-of-descent = "-3.0 deg"
 
 [Fuselage]
@@ -143,12 +104,14 @@
 
 [Fuselage.Geometry]
     number_of_bubbles = 1  # SingleBubble or MultiBubble Designs
-    radius = "77 in"       # Fuselage radius
-    dRadius = "15 in"      # Downward shift of lower bubbles
+    radius = "59.5 in"       # Fuselage radius
+    dRadius = "13.0 in"      # Downward shift of lower bubbles
     y_offset = 0.0         # y offset of bubble center
-    floor_depth = "5.0 in" # depth of floor beams
-    a_nose = 1.65 # Nose radius = Rfuse*(1 - xi^a_nose)^(1/a_nose)
-    b_tail = 2.0 # Tail radius = Rfuse*(1 - xi^b_tail)
+    floor_depth = "6.0 in" # depth of floor beams
+    Nwebs = 0              # number of webs (for double bubble designs)
+
+    a_nose = 1.7 # Nose radius = Rfuse*(1 - xi^a_nose)^(1/a_nose)
+    b_tail = 1.75 # Tail radius = Rfuse*(1 - xi^b_tail)
     tailcone_taper = 0.3
     taper_fuse_to = "point" # Options are "point" or "edge"
     
@@ -160,7 +123,6 @@
     calculate_cabin_length = false 
 
     double_decker   = false #if true, the fuselage has two passenger decks
-    floor_distance  = "0 in" #Vertical distance between floors if double decker
     seat_pitch      = "30 in"
     seat_width      = "19 in"
     aisle_halfwidth = "10 in"
@@ -168,25 +130,24 @@
     #Provided layout
     x_nose_tip           = "0 ft"
     x_pressure_shell_fwd = "17 ft"
-    x_start_cylinder     = "20 ft"
+    x_start_cylinder     = "15 ft"
     x_end_cylinder       = "97 ft"
-    x_pressure_shell_aft = "102 ft"
+    x_pressure_shell_aft = "103 ft"
     x_cone_end           = "117 ft"
-    x_end                = "124 ft"
+    x_end                = "127 ft"
     
 # Power systems and landing gear locations
-    x_HPE_sys = "62ft" #Hydraulic, Pneumatic and Electrical systems
+    x_HPE_sys = "60ft" #Hydraulic, Pneumatic and Electrical systems
     x_nose_landing_gear        = "14ft"
     x_main_landing_gear_offset = "1 ft" # main LG offset behind the wing lift centroid
 
-    x_APU = "120 ft"
+    x_APU = "122 ft"
 
     x_fixed_weight = "7ft" #Cockpit/ pilots etc
 
 # Engine positions
-    x_engines = "52 ft"
-    y_critical_engines = "16 ft" # y location of engines that would cause max yaw
-
+    x_engines = "47 ft"
+    y_critical_engines = "14.5 ft" # y location of engines that would cause max yaw here
 
 [Fuselage.Weights]
     stringer = 0.35   # (Weight of stringers)/ Wskin
@@ -208,14 +169,14 @@
     add_payload_weight_fraction = 0.35 # Additional payload proportional Wfrac
 
 [Fuselage.Aero]
-    fuse_moment_volume_deriv = "2390.0 ft3" # d(Mfuse/q)/dCL
+    fuse_moment_volume_deriv = "1450.0 ft3" # d(Mfuse/q)/dCL
     CL_zero_fuse_moment      = 0.185         # CL when Mfuse = 0
     #Fuselage velocity overspeed at wing
-    wingroot_fuse_overspeed  = 0.018
-    wingbreak_fuse_overspeed = 0.014
-    wingtip_fuse_overspeed   = 0.0045
+    wingroot_fuse_overspeed  = 0.0125
+    wingbreak_fuse_overspeed = 0.01
+    wingtip_fuse_overspeed   = 0.003
 
-    excrescence_drag_factor = 1.03 # Rivets, sheet breaks etc
+    excrescence_drag_factor = 1.1 # Rivets, sheet breaks etc
 
     BLI_frac = 0.0 #Fraction of fuselage BL KE defect ingested
 
@@ -225,25 +186,25 @@
     strut_braced_wing = false
 
     sweep = 26.0 # wing sweep in degrees
-    AR    = 10.1
-    maxSpan = "117.5 ft"
+    AR    = 8.7
+    maxSpan = "100 ft"
 
     inner_panel_taper_ratio = 0.7  #cs/co
-    outer_panel_taper_ratio = 0.25 #ct/co
+    outer_panel_taper_ratio = 0.225 #ct/co
 
-    panel_break_location = 0.285 # eta_s panel break eta location. eta = y/b
+    panel_break_location = 0.370 # eta_s panel break eta location. eta = y/b
     
-    center_box_halfspan = "71.0 in"
+    center_box_halfspan = "4.30 ft"
     box_width_chord = 0.50
-    root_thickness_to_chord = 0.1268
-    spanbreak_thickness_to_chord = 0.1266
+    root_thickness_to_chord = 0.135
+    spanbreak_thickness_to_chord = 0.12
 
     hweb_to_hbox = 0.75 #web-height/hbox ratio
     spar_box_x_c = 0.40 # spar box axis x/c location
 
-    x_wing_box = "57 ft"
-    z_wing  = "-5.5 ft"
-    z_strut = "154 in" #Note only used if `strut_braced_wing = true`
+    x_wing_box = "55 ft"
+    z_wing  = "-4.0 ft"
+    z_strut = "154 in" #Note only used if `strut_braced_wing = true` CHECK
 
     #Only used if `sturt_braced_wing == true`:
     strut_toc = 0.15 #strut thickness to chord
@@ -264,7 +225,7 @@
 
     Reynolds_scaling = -0.15 # = aRe, used for Re-scaling CD = cd*(Re/Re_ref)^aRe
 
-    excrescence_drag_factor = 1.02 # Rivets, sheet breaks etc
+    excrescence_drag_factor = 1.08 # Rivets, sheet breaks etc
 
     BLI_frac = 0.0 #Fraction of wing BL KE defect ingested
 
@@ -277,8 +238,8 @@
     cm_t = -0.02 # tip section cm
 
 [Wing.Aero.Climb] #used for all clean situations
-    cls_clo = 1.238 #rcls = break/root cl ratio = cls/clo
-    clt_clo = 0.90 #rclt = tip  /root cl ratio = clt/clo
+    cls_clo = 1.3 #rcls = break/root cl ratio = cls/clo
+    clt_clo = 1.25 #rclt = tip  /root cl ratio = clt/clo
     cm_o = -0.06 # root section cm
     cm_s = -0.06 # span-break section cm
     cm_t = -0.06 # tip section cm
@@ -288,7 +249,7 @@
     clt_clo = 0.5 #rclt = tip  /root cl ratio = clt/clo
     cm_o = -0.35 # root section cm
     cm_s = -0.35 # span-break section cm
-    cm_t = -0.02 # tip section cm
+    cm_t = -0.15 # tip section cm
 
 [Wing.Weightfracs]
     # Weight fractions of flight surfaces and secondary wing components
@@ -307,36 +268,36 @@
 
     #Tail profile drags:
     lowspeed_cdf = 0.0060
-    lowspeed_cdp = 0.0035
+    lowspeed_cdp = 0.0030
     Re_ref       = 10e6
 
-    excrescence_drag_factor = 1.02 # Rivets, sheet breaks etc
+    excrescence_drag_factor = 1.08 # Rivets, sheet breaks etc
 
     [Stabilizers.Htail]
-        AR_Htail = 6.0
+        AR_Htail = 5.8
         taper = 0.25
-        sweep = 26.0 #typically can be set to be the same as the wings
+        sweep = 25.0 #typically can be set to be the same as the wings
         center_box_halfspan = "2.5 ft"
-        x_Htail = "114.5 ft"
-        z_Htail = "0 ft"
+        x_Htail = "115 ft"
+        z_Htail = "4 ft"
 
         max_tail_download = -0.5 # = CLh/CLmax. Tail download param at max load case.
         
         # How do you want to size the horizontal stabilizers?
-        HTsize = "Vh" # Options are "Vh" or "maxforwardCG" 
+        HTsize = "maxforwardCG" # Options are "Vh" or "maxforwardCG" 
         # 1: set Sh via specified Vh
         # 2: set Sh via CLhCGfwd at max-forward CG during landing
-        Vh = 1.45 # Horizontal tail volume (only used if HTsize == "Vh")
-        CLh_at_max_forward_CG = -0.7 # (only used if HTsize == "maxforwardCG")
+        Vh = 1.3 # Horizontal tail volume (only used if HTsize == "Vh")
+        CLh_at_max_forward_CG = -0.6 # (only used if HTsize == "maxforwardCG")
 
         move_wingbox = "SMmin" # 0: "fix" wing position 
                              # 1: move wing to get CLh="CLhspec" in cruise 
                              # 2: move wing to get min static margin = "SMmin"
 
-        SM_min = 0.05 # Minimum static margin
+        SM_min = 0.15 # Minimum static margin
         CLh_spec = -0.02
 
-        downwash_factor = 0.60 #dε/dα
+        downwash_factor = 0.55 #dε/dα
         nacelle_lift_curve_slope = 3.8 #dCL_nacelle/dα
                                        # Recommend ~3.8 for wing mounted nacelle
                                        #           ~0.0 for rear mounted nacelle
@@ -346,7 +307,7 @@
         added_weight_fraction = 0.30 # e.g. ribs, LE, elevator, attachments
 
         box_width_chord = 0.50
-        box_height_chord = 0.14
+        box_height_chord = 0.12
         web_height_hbox  = 0.75
 
     [Stabilizers.Vtail]
@@ -354,20 +315,20 @@
         taper = 0.30
         sweep = 25.0
         center_box_halfspan = 0.0
-        x_Vtail = "110 ft"
+        x_Vtail = "113 ft"
         number_Vtails = 1.0
 
         VTsize = "Vv" # Options are "Vv" or "OEI"
         # 1: set Vtail area Sv via specified Vv
         # 2: set Vtail area Sv via engine-out trim CL
-        Vv = 0.1 # only used if VTsize == "Vv"
+        Vv = 0.12 # only used if VTsize == "Vv"
         CLv_at_engine_out = 0.5 # only used if VTsize == "OEI"
         CLv_max = 2.6
 
         added_weight_fraction = 0.40 # e.g. ribs, LE, rudder, attachments
 
         box_width_chord = 0.50
-        box_height_chord = 0.14 
+        box_height_chord = 0.12
         web_height_hbox  = 0.75
 
 [Structures]
@@ -411,38 +372,38 @@
 [Propulsion]
 
     number_of_engines = 2
-    T_max_metal = 1280.0
+    T_max_metal = 1250.0
 
-    Tt4_takeoff = 1833.0
+    Tt4_takeoff = 1541.7
     Tt4_frac_bottom_of_climb = 0.2
     Tt4_frac_top_of_climb = 0.2
-    Tt4_cruise = 1587.0
+    Tt4_cruise = 1326.6
 
     # Core in clean flow or does core ingests KE defect?
     core_in_clean_flow = true
 
 [Propulsion.Turbomachinery]
 
-    BPR = 5.1
+    BPR = 5.0
     gear_ratio = 1.0 #Fan gear ratio. 1 => direct drive turbofan
 
-    OPR    = 30.0
-    Fan_PR = 1.685
-    LPC_PR = 2.5
+    OPR    = 28.0
+    Fan_PR = 1.6
+    LPC_PR = 8.0
     
-    diffuser_PR    = 0.998
+    diffuser_PR    = 0.995
     burner_PR      = 0.94
     fan_nozzle_PR  = 0.98
-    core_nozzle_PR = 0.989
+    core_nozzle_PR = 0.995
 
-    fan_eta_poly = 0.8948
-    LPC_eta_poly = 0.88
-    HPC_eta_poly = 0.87
-    HPT_eta_poly = 0.889
-    LPT_eta_poly = 0.899
+    fan_eta_poly = 0.9
+    LPC_eta_poly = 0.89
+    HPC_eta_poly = 0.88
+    HPT_eta_poly = 0.9
+    LPT_eta_poly = 0.9
 
     #Fan efficiency function constants -> epoly_actual = epolyf + Kf*(FPR-FPR0)
-    FPR0 = 1.685
+    FPR0 = 1.65
     Kf_polyeff = -0.077 
 
     HTR_fan = 0.30
@@ -456,7 +417,7 @@
     high_spool_loss = 0.022
 
 [Propulsion.Combustor]
-    combustion_efficiency = 0.98
+    combustion_efficiency = 0.985
 
 [Propulsion.Cooling]
     hot_streak_T_allowance = 200.0
@@ -465,17 +426,17 @@
     e_film_cooling = 0.70 #blade-to-cooling flow heat transfer eff
     t_film_cooling = 0.30 #cooling-film effectiveness factor
     M41 = 0.9 # Mach number at start of cooling-air mixing zone
-    cooling_air_V_ratio = 0.15 #v_cool/v_edge velocity ratio of exiting cooling air
+    cooling_air_V_ratio = 0.3 #v_cool/v_edge velocity ratio of exiting cooling air
 
 [Propulsion.Offtakes]
-    LPC_mass_offtake_per_pax = 0.0063
-    LPC_mass_offtake_per_max_mass = 0.0
+    LPC_mass_offtake_per_pax = 0.008
+    LPC_mass_offtake_per_max_mass = 0.0000085
 
     Low_spool_power_offtake_per_pax = 200.0
-    Low_spool_power_offtake_per_max_mass = 1.8
+    Low_spool_power_offtake_per_max_mass = 0.5
 
     Tt_offtake_air = 300.0
-    Pt_offtake_air = 30e3
+    Pt_offtake_air = 30000.0
 
 [Propulsion.Nozzles]
 #Nozzle area factors relative to cruise design_area

--- a/src/IO/default_wide.toml
+++ b/src/IO/default_wide.toml
@@ -1,16 +1,13 @@
 # This is a template TOML input file and are the default values that will
 # be used by TASOPT
 ["Aircraft Description"]
-    name = "Default TASOPT Model"
+    name = "Wide Body TASOPT Model"
     description = """
-    This model file describes a basic single-aisle aircraft to 
-    demonstrate how to define a model file. The contents of this file are 
-    also loaded by the `TASOPT.jl` package as default if no other details are 
-    provided by the user.
+    This model file describes a basic twin-aisle aircraft.
     """
-    aircraft_type   = "Narrow Body"     # 0: Regional Aircraft
-                                    # 1: Narrow Body Aircraft
-                                    # 2: Wide Body Aircraft
+    aircraft_type   = "Wide Body Aircraft"  # 0: Regional Aircraft
+                                        # 1: Narrow Body Aircraft
+                                        # 2: Wide Body Aircraft
 
 #-------------------------------------------------#
 ##               Note on units                   ##
@@ -41,6 +38,7 @@
 # ╚══════════╩══════════╩═════╩═══════╩═══════╩════╝
 
 [Options] #
+
     optimize        = false   # Do you want TASOPT to optimize the aircraft or just size it 
     
     engine_location = "wing" # 1: Engines on "wing"
@@ -49,74 +47,39 @@
     prop_sys_arch = "TF" #Options are TF: Turbofan
                          #            TE: Turbo-electric
 [Fuel]
-    fuel_type       = "Jet-A" # Choices are "Jet-A", "LH2" and "CH4"
+    fuel_type       = "Jet-A" # Choices are ... [TODO]
     fuel_in_wing    = true # Is fuel stored in wings?
     fuel_in_wingcen = true # Is fuel stored in wing center box?
-    fuel_usability_factor = 0.90 # fraction of max fuel volume that is usable
+    fuel_usability_factor = 1 # fraction of max fuel volume that is usable
 
     fuel_temp = 280.0
-    fuel_density = 817.0 #kg/m3
+    fuel_density = 810.0 #kg/m3
 
-[Fuel.Storage] #Default fuselage fuel storage parameters for cryogenic fuels
-    tank_placement = "rear" #Location of tank in fuselage. Choices are "front", "rear", or "both".
-
-    tank_aspect_ratio = 2.0
-    fuselage_clearance = "0.3 ft"
-    additional_mass_fraction = 0.25
-    weld_efficiency = 0.9 
-    ullage_fraction = 0.05 #minimum ullage fraction at tank venting pressure
-    heat_leak_factor = 1.3 #Factor to account for heat leakage through structural elements, piping, etc (qfac > 1)
-    SL_temperature_for_tank = "288.2 K"
-
-    #Tank pressure design parameters
-    pressure_rise_factor = 2.0 #Factor to account for stratification in homogenous tank model (pfac >= 1)
-    pressure_venting = "2 atm"
-    pressure_initial = "1.2 atm"
-    hold_departure = "0 h"
-    hold_arrival = "0 h"
-
-    inner_vessel_material = "Al-2219-T87"
-    inner_vessel_support_angle = "80 deg"
-    
-    #Insulation options: "rohacell41S", "polyurethane27", "polyurethane32", "polyurethane35", "vacuum", "mylar", "microspheres"
-    size_insulation = true #Flag to decide whether to size insulation for boiloff
-    insulation_material = ["polyurethane32", "polyurethane32", "polyurethane32"] 
-    insulation_segment_base_thickness = [0.05, 0.05, 0.05] #m
-    
-    cruise_boiloff_rate = 0.4 #%/hour, used if size_insulation == true
-    insulation_thicknesses_design_indices = [1,2,3] #insulation segments to size if size_insulation == true
-
-    #Parameters for double-walled tank, if "vacuum" is in insulation_material
-    outer_vessel_material = "Al-2219-T87"
-    outer_vessel_support_angles = ["45 deg", "135 deg"]
-    
 [Mission]
-    N_missions = 2 # Number of missions to be modeled (first mission is the design mission)
-    max_pax = 230               # Maximum number of passengers for aircarft
+    N_missions = 1 # Number of missions to be modeled (first mission is the design mission)
+    pax = 370            # Number of passengers in each mission
+    max_pax = 450               # Maximum number of passengers for aircarft
                                 # defines the maximum payload carrying capacity of the aircraft
                                 
-    range = ["3000.0 nmi", "2000.0 nmi"] # Design Range + second mission range
+    range = "7800.0 nmi" # Design Range 
 
-    pax = [180, 150]                    # Number of passengers in each mission
-                                        # weight per pax also specified (215 lbf/pax is std)
+    weight_per_pax = "230.0 lbf" # Specify weight per passenger - 
+                            # includes luggage [lbm or lbf or kg or N] 
+                            # judging you if you use imperial units but wtvs
 
-    weight_per_pax = "215.0 lbf"    # Specify weight per passenger - 
-                                    # includes luggage [lbm or lbf or kg or N] 
-                                    # judging you if you use imperial units but wtvs
-
-    fuel_reserves = 0.20 # W_reserveFuel / W_fuelburned
+    fuel_reserves = 0.07 # W_reserveFuel / W_fuelburned
 
     Nlift = 3.0 # Max vertical load factor for wing bending loads
     Vne = "280 kts" # Never exceed IAS for tail loads
 
 [Mission.Takeoff]
-    takeoff_alt = ["0.0 ft", "500 ft"] 
-    takeoff_T = [288.2, 298.0]
+    takeoff_alt = "0.0 ft"
+    takeoff_T = 288.2
 
-    max_balanced_field_length = "8000.0 ft"
+    max_balanced_field_length = "8800.0 ft"
     Nland = 6.0 # Max vertical load factor for fuse bending loads
 
-    CL_max_perp     = 2.25  #CLmax/(cos(sweep))^2
+    CL_max_perp     = 2.8  #CLmax/(cos(sweep))^2
     CD_dead_engine  = 0.50  #CDA_fan/ A_fan
     CD_landing_gear = 0.015 #CD*Agear/ Sref
     CD_spoilers     = 0.10  #CD*Aspoiler/ Sref
@@ -130,23 +93,25 @@
     minimum_top-of-climb_gradient = 0.015
 
 [Mission.Cruise]
-    cruise_alt  = ["35000.0 ft", "30e3 ft"]
-    cruise_mach = 0.80
-    cruise_CL   = 0.57
+    cruise_alt  = "32000.0 ft"
+    cruise_mach = 0.84
+    cruise_CL   = 0.51
 
 [Mission.Descent]
-    descent_angle_top-of-descent = "-3.0 deg"
-    descent_angle_bottom-of-descent = "-3.0 deg"
+    descent_angle_top-of-descent = "-3 deg"
+    descent_angle_bottom-of-descent = "-3 deg"
 
 [Fuselage]
     cabin_pressure_altitude = "8000.0 ft"
 
 [Fuselage.Geometry]
     number_of_bubbles = 1  # SingleBubble or MultiBubble Designs
-    radius = "77 in"       # Fuselage radius
-    dRadius = "15 in"      # Downward shift of lower bubbles
+    radius = "122 in"       # Fuselage radius
+    dRadius = "0 in"      # Downward shift of lower bubbles
     y_offset = 0.0         # y offset of bubble center
-    floor_depth = "5.0 in" # depth of floor beams
+    floor_depth = "8.0 in" # depth of floor beams
+    Nwebs = 0              # number of webs (for double bubble designs)
+
     a_nose = 1.65 # Nose radius = Rfuse*(1 - xi^a_nose)^(1/a_nose)
     b_tail = 2.0 # Tail radius = Rfuse*(1 - xi^b_tail)
     tailcone_taper = 0.3
@@ -160,60 +125,59 @@
     calculate_cabin_length = false 
 
     double_decker   = false #if true, the fuselage has two passenger decks
-    floor_distance  = "0 in" #Vertical distance between floors if double decker
     seat_pitch      = "30 in"
     seat_width      = "19 in"
     aisle_halfwidth = "10 in"
 
     #Provided layout
     x_nose_tip           = "0 ft"
-    x_pressure_shell_fwd = "17 ft"
-    x_start_cylinder     = "20 ft"
-    x_end_cylinder       = "97 ft"
-    x_pressure_shell_aft = "102 ft"
-    x_cone_end           = "117 ft"
-    x_end                = "124 ft"
+    x_pressure_shell_fwd = "38 ft"
+    x_start_cylinder     = "40 ft"
+    x_end_cylinder       = "171 ft"
+    x_pressure_shell_aft = "204 ft"
+    x_cone_end           = "235 ft"
+    x_end                = "242 ft"
     
 # Power systems and landing gear locations
-    x_HPE_sys = "62ft" #Hydraulic, Pneumatic and Electrical systems
-    x_nose_landing_gear        = "14ft"
-    x_main_landing_gear_offset = "1 ft" # main LG offset behind the wing lift centroid
+    x_HPE_sys = "125 ft" #Hydraulic, Pneumatic and Electrical systems
+    x_nose_landing_gear        = "28 ft"
+    x_main_landing_gear_offset = "3 ft" # main LG offset behind the wing lift centroid
 
-    x_APU = "120 ft"
+    x_APU = "232 ft"
 
-    x_fixed_weight = "7ft" #Cockpit/ pilots etc
+    x_fixed_weight = "10 ft" #Cockpit/ pilots etc
 
 # Engine positions
-    x_engines = "52 ft"
-    y_critical_engines = "16 ft" # y location of engines that would cause max yaw
+    x_engines = "102 ft"
+    y_critical_engines = "32 ft" # y location of engines that would cause max yaw
 
 
 [Fuselage.Weights]
     stringer = 0.35   # (Weight of stringers)/ Wskin
-    frame    = 0.25   # (Weight of frame)/ Wskin
+    frame    = 0.24   # (Weight of frame)/ Wskin
     additional = 0.20 # (Additional weight)/ Wskin
 
     fixed_weight = "3000 lbf" #cockpit, pilots etc
 
-    window_per_length     = 435.0 #[N/m]
-    window_insul_per_area =  22.0 #[N/m2]
+    window_per_length     = 145.0 #[N/m]
+    window_insul_per_area =  40.0 #[N/m2]
     floor_weight_per_area =  60.0 #[N/m2]
 
     HPE_sys_weight_fraction = 0.010 # W_HPEsys/WMTO
-    LG_nose_weight_fraction = 0.011 # Wlgnose/WMTO
-    LG_main_weight_fraction = 0.044 # Wlgmain/WMTO
+    LG_nose_weight_fraction = 0.010 # Wlgnose/WMTO
+    LG_main_weight_fraction = 0.040 # Wlgmain/WMTO
 
     APU_weight_fraction = 0.035 # W_APU/W_payload
     seat_weight_fraction = 0.10 # Wseats/W_payload
     add_payload_weight_fraction = 0.35 # Additional payload proportional Wfrac
 
 [Fuselage.Aero]
-    fuse_moment_volume_deriv = "2390.0 ft3" # d(Mfuse/q)/dCL
+    fuse_moment_volume_deriv = "7470.0 ft3" # d(Mfuse/q)/dCL
     CL_zero_fuse_moment      = 0.185         # CL when Mfuse = 0
     #Fuselage velocity overspeed at wing
-    wingroot_fuse_overspeed  = 0.018
+    wingroot_fuse_overspeed  = 0.019
     wingbreak_fuse_overspeed = 0.014
-    wingtip_fuse_overspeed   = 0.0045
+    wingtip_fuse_overspeed   = 0.004
 
     excrescence_drag_factor = 1.03 # Rivets, sheet breaks etc
 
@@ -224,25 +188,25 @@
                       # 1: Wing cantilever with engine
     strut_braced_wing = false
 
-    sweep = 26.0 # wing sweep in degrees
-    AR    = 10.1
-    maxSpan = "117.5 ft"
+    sweep = 29 # wing sweep in degrees
+    AR    = 8.8
+    maxSpan = "213 ft"
 
-    inner_panel_taper_ratio = 0.7  #cs/co
-    outer_panel_taper_ratio = 0.25 #ct/co
+    inner_panel_taper_ratio = 0.58  #cs/co #NOT CHANGED
+    outer_panel_taper_ratio = 0.1 #ct/co
 
-    panel_break_location = 0.285 # eta_s panel break eta location. eta = y/b
+    panel_break_location = 0.32 # eta_s panel break eta location. eta = y/b
     
-    center_box_halfspan = "71.0 in"
+    center_box_halfspan = "120.0 in"
     box_width_chord = 0.50
-    root_thickness_to_chord = 0.1268
-    spanbreak_thickness_to_chord = 0.1266
+    root_thickness_to_chord = 0.1
+    spanbreak_thickness_to_chord = 0.108
 
-    hweb_to_hbox = 0.75 #web-height/hbox ratio
-    spar_box_x_c = 0.40 # spar box axis x/c location
+    hweb_to_hbox = 0.9 #web-height/hbox ratio
+    spar_box_x_c = 0.04 # spar box axis x/c location
 
-    x_wing_box = "57 ft"
-    z_wing  = "-5.5 ft"
+    x_wing_box = "114 ft"
+    z_wing  = "-7 ft"
     z_strut = "154 in" #Note only used if `strut_braced_wing = true`
 
     #Only used if `sturt_braced_wing == true`:
@@ -272,23 +236,23 @@
 [Wing.Aero.Takeoff]
     cls_clo = 1.1 #rcls = break/root cl ratio = cls/clo
     clt_clo = 0.6 #rclt = tip  /root cl ratio = clt/clo
-    cm_o = -0.20 # root section cm
-    cm_s = -0.20 # span-break section cm
-    cm_t = -0.02 # tip section cm
+    cm_o = -0.30 # root section cm
+    cm_s = -0.30 # span-break section cm
+    cm_t = -0.05 # tip section cm
 
 [Wing.Aero.Climb] #used for all clean situations
-    cls_clo = 1.238 #rcls = break/root cl ratio = cls/clo
-    clt_clo = 0.90 #rclt = tip  /root cl ratio = clt/clo
-    cm_o = -0.06 # root section cm
-    cm_s = -0.06 # span-break section cm
-    cm_t = -0.06 # tip section cm
+    cls_clo = 1.1320 #rcls = break/root cl ratio = cls/clo
+    clt_clo = 1.0266 #rclt = tip  /root cl ratio = clt/clo #TODO
+    cm_o = -0.1 # root section cm
+    cm_s = -0.1 # span-break section cm
+    cm_t = -0.1 # tip section cm
 
 [Wing.Aero.Landing] #Forward-CG tail sizing case
-    cls_clo = 1.1 #rcls = break/root cl ratio = cls/clo
-    clt_clo = 0.5 #rclt = tip  /root cl ratio = clt/clo
-    cm_o = -0.35 # root section cm
-    cm_s = -0.35 # span-break section cm
-    cm_t = -0.02 # tip section cm
+    cls_clo = 1.1320  #rcls = break/root cl ratio = cls/clo
+    clt_clo = 1.0266 #rclt = tip  /root cl ratio = clt/clo
+    cm_o = -0.1 # root section cm
+    cm_s = -0.1 # span-break section cm
+    cm_t = -0.1 # tip section cm
 
 [Wing.Weightfracs]
     # Weight fractions of flight surfaces and secondary wing components
@@ -297,7 +261,7 @@
     slat = 0.1 #slats, slat mounts and actuators weight fraction
     aileron = 0.04 #ailerons, aileron mounts and actuators weight fraction
     leading_trailing_edge = 0.1
-    ribs = 0.15        # Ribs, local stiffeners, reinforcements
+    ribs = 0.15     # Ribs, local stiffeners, reinforcements
     spoilers = 0.020   # Spoilers, spolier mounts and attachements
     attachments = 0.03 # Wing attachment hardware
 
@@ -313,27 +277,27 @@
     excrescence_drag_factor = 1.02 # Rivets, sheet breaks etc
 
     [Stabilizers.Htail]
-        AR_Htail = 6.0
-        taper = 0.25
-        sweep = 26.0 #typically can be set to be the same as the wings
-        center_box_halfspan = "2.5 ft"
-        x_Htail = "114.5 ft"
-        z_Htail = "0 ft"
+        AR_Htail = 4.8
+        taper = 0.32
+        sweep = 33.0 #typically can be set to be the same as the wings
+        center_box_halfspan = "5 ft"
+        x_Htail = "220 ft"
+        z_Htail = "9 ft"
 
         max_tail_download = -0.5 # = CLh/CLmax. Tail download param at max load case.
         
         # How do you want to size the horizontal stabilizers?
-        HTsize = "Vh" # Options are "Vh" or "maxforwardCG" 
+        HTsize = "maxforwardCG" # Options are "Vh" or "maxforwardCG" 
         # 1: set Sh via specified Vh
         # 2: set Sh via CLhCGfwd at max-forward CG during landing
-        Vh = 1.45 # Horizontal tail volume (only used if HTsize == "Vh")
-        CLh_at_max_forward_CG = -0.7 # (only used if HTsize == "maxforwardCG")
+        Vh = 0.85 # Horizontal tail volume (only used if HTsize == "Vh")
+        CLh_at_max_forward_CG = -1 # (only used if HTsize == "maxforwardCG")
 
         move_wingbox = "SMmin" # 0: "fix" wing position 
                              # 1: move wing to get CLh="CLhspec" in cruise 
                              # 2: move wing to get min static margin = "SMmin"
 
-        SM_min = 0.05 # Minimum static margin
+        SM_min = 0.15 # Minimum static margin
         CLh_spec = -0.02
 
         downwash_factor = 0.60 #dε/dα
@@ -341,7 +305,7 @@
                                        # Recommend ~3.8 for wing mounted nacelle
                                        #           ~0.0 for rear mounted nacelle
         CD_Htail_from_center = 0.1 #CDhtail contribution factor from center part 0 < y < yoh
-        CLh_max = 2.0
+        CLh_max = 1.5
 
         added_weight_fraction = 0.30 # e.g. ribs, LE, elevator, attachments
 
@@ -350,19 +314,19 @@
         web_height_hbox  = 0.75
 
     [Stabilizers.Vtail]
-        AR_Vtail = 2.0
-        taper = 0.30
-        sweep = 25.0
+        AR_Vtail = 2.35
+        taper = 0.25
+        sweep = 28.0
         center_box_halfspan = 0.0
-        x_Vtail = "110 ft"
+        x_Vtail = "212 ft"
         number_Vtails = 1.0
 
         VTsize = "Vv" # Options are "Vv" or "OEI"
         # 1: set Vtail area Sv via specified Vv
         # 2: set Vtail area Sv via engine-out trim CL
-        Vv = 0.1 # only used if VTsize == "Vv"
-        CLv_at_engine_out = 0.5 # only used if VTsize == "OEI"
-        CLv_max = 2.6
+        Vv = 0.06 # only used if VTsize == "Vv"
+        CLv_at_engine_out = 11.675933 # 0.5 # only used if VTsize == "OEI"
+        CLv_max = 2.0
 
         added_weight_fraction = 0.40 # e.g. ribs, LE, rudder, attachments
 
@@ -411,68 +375,69 @@
 [Propulsion]
 
     number_of_engines = 2
-    T_max_metal = 1280.0
+    T_max_metal = 1350
 
-    Tt4_takeoff = 1833.0
+    Tt4_takeoff = 1785.6
     Tt4_frac_bottom_of_climb = 0.2
     Tt4_frac_top_of_climb = 0.2
-    Tt4_cruise = 1587.0
+    Tt4_cruise = 1590.6
 
     # Core in clean flow or does core ingests KE defect?
     core_in_clean_flow = true
 
 [Propulsion.Turbomachinery]
 
-    BPR = 5.1
-    gear_ratio = 1.0 #Fan gear ratio. 1 => direct drive turbofan
+    BPR = 7.2
+    gear_ratio = 1.0 #Fan gear ratio. 1 => direct drive turbofan TODO
 
-    OPR    = 30.0
-    Fan_PR = 1.685
-    LPC_PR = 2.5
+    OPR    = 39.9
+    Fan_PR = 1.6
+    LPC_PR = 1.86
     
-    diffuser_PR    = 0.998
+    #Commented out means I couldn't find the values and thus using default
+    diffuser_PR    = 0.995
     burner_PR      = 0.94
-    fan_nozzle_PR  = 0.98
-    core_nozzle_PR = 0.989
+    fan_nozzle_PR  = 0.985
+    core_nozzle_PR = 0.995
 
-    fan_eta_poly = 0.8948
-    LPC_eta_poly = 0.88
-    HPC_eta_poly = 0.87
-    HPT_eta_poly = 0.889
-    LPT_eta_poly = 0.899
+    fan_eta_poly = 0.916
+    LPC_eta_poly = 0.908
+    HPC_eta_poly = 0.902
+    HPT_eta_poly = 0.896
+    LPT_eta_poly = 0.905
 
     #Fan efficiency function constants -> epoly_actual = epolyf + Kf*(FPR-FPR0)
-    FPR0 = 1.685
+    FPR0 = 1.55
     Kf_polyeff = -0.077 
 
     HTR_fan = 0.30
     HTR_LPC = 0.60
     HTR_HPC = 0.80
 
-    M2  = 0.60
+    M2  = 0.65
     M25 = 0.60
 
     low_spool_loss  = 0.01
     high_spool_loss = 0.022
 
 [Propulsion.Combustor]
-    combustion_efficiency = 0.98
+    combustion_efficiency = 0.985
 
 [Propulsion.Cooling]
     hot_streak_T_allowance = 200.0
     M_turbine_blade_exit = 1.0
-    St = 0.09 # area-weighted effective Stanton number
+    St = 0.08 # area-weighted effective Stanton number
     e_film_cooling = 0.70 #blade-to-cooling flow heat transfer eff
     t_film_cooling = 0.30 #cooling-film effectiveness factor
-    M41 = 0.9 # Mach number at start of cooling-air mixing zone
-    cooling_air_V_ratio = 0.15 #v_cool/v_edge velocity ratio of exiting cooling air
+    M41 = 1.0 # Mach number at start of cooling-air mixing zone
+    cooling_air_V_ratio = 0.3 #v_cool/v_edge velocity ratio of exiting cooling air
 
 [Propulsion.Offtakes]
-    LPC_mass_offtake_per_pax = 0.0063
-    LPC_mass_offtake_per_max_mass = 0.0
+    LPC_mass_offtake_per_pax = 0.008
+    LPC_mass_offtake_per_max_mass = 0.0000085
 
     Low_spool_power_offtake_per_pax = 200.0
-    Low_spool_power_offtake_per_max_mass = 1.8
+    Low_spool_power_offtake_per_max_mass = 0.5
 
     Tt_offtake_air = 300.0
     Pt_offtake_air = 30e3
@@ -498,7 +463,7 @@
 
 
 [Propulsion.Nacelles]
-    nacelle_pylon_wetted_area_ratio = 16.0 # = rSnace = wetted area/fan area
+    nacelle_pylon_wetted_area_ratio = 12.0 # = rSnace = wetted area/fan area
     nacelle_local_velocity_ratio = 1.02 # local/freestream velocity
 
 [Propulsion.HeatExchangers] #Default model does not have heat exchangers in the propulsion system
@@ -525,7 +490,7 @@
     
 [Propulsion.Weight]
     engine_access_weight_fraction = 0.10 # feadd    Weadd/Wbare   engine accessories, fuel system fraction 
-    pylon_weight_fraction = 0.10  # fpylon   Wpylon/We+a+n engine pylon weight fraction   
+    pylon_weight_fraction = 0.05  # fpylon   Wpylon/We+a+n engine pylon weight fraction   
     weight_model = "basic" #Options are "MD": Mark Drela's original model
                               #   "basic": NF's new model with basic tech
                               #"advanced": NF's new model with advanced tech

--- a/src/IO/read_input.jl
+++ b/src/IO/read_input.jl
@@ -28,11 +28,11 @@ function read_input(k::String, dict::AbstractDict=data,
 end
 
 function get_default_input_file(input)
-    if input == 0 || input == "Regional Aircraft"
+    if input == 0 || lowercase(input) == "regional aircraft"
         defaultfile = joinpath(TASOPT.__TASOPTroot__, "IO/default_regional.toml")
-    elseif input == 1 || input == "Narrow Body Aircraft"
+    elseif input == 1 || lowercase(input) == "narrow body aircraft"
         defaultfile = joinpath(TASOPT.__TASOPTroot__, "IO/default_input.toml")
-    elseif input == 2 || input == "Wide Body Aircraft"
+    elseif input == 2 || lowercase(input) == "wide body aircraft"
         defaultfile = joinpath(TASOPT.__TASOPTroot__, "IO/default_wide.toml")
     else
         println("\n")

--- a/src/IO/read_input.jl
+++ b/src/IO/read_input.jl
@@ -28,11 +28,11 @@ function read_input(k::String, dict::AbstractDict=data,
 end
 
 function get_default_input_file(input)
-    if input == 0 || lowercase(input) == "regional aircraft"
+    if input == 0 || lowercase(string(input)) == "regional aircraft"
         defaultfile = joinpath(TASOPT.__TASOPTroot__, "IO/default_regional.toml")
-    elseif input == 1 || lowercase(input) == "narrow body aircraft"
+    elseif input == 1 || lowercase(string(input)) == "narrow body aircraft"
         defaultfile = joinpath(TASOPT.__TASOPTroot__, "IO/default_input.toml")
-    elseif input == 2 || lowercase(input) == "wide body aircraft"
+    elseif input == 2 || lowercase(string(input)) == "wide body aircraft"
         defaultfile = joinpath(TASOPT.__TASOPTroot__, "IO/default_wide.toml")
     else
         println("\n")

--- a/src/IO/read_input.jl
+++ b/src/IO/read_input.jl
@@ -27,6 +27,20 @@ function read_input(k::String, dict::AbstractDict=data,
     end
 end
 
+function get_default_input_file(input)
+    if input == 0 || input == "Regional Aircraft"
+        defaultfile = joinpath(TASOPT.__TASOPTroot__, "IO/default_regional.toml")
+    elseif input == 1 || input == "Narrow Body Aircraft"
+        defaultfile = joinpath(TASOPT.__TASOPTroot__, "IO/default_input.toml")
+    elseif input == 2 || input == "Wide Body Aircraft"
+        defaultfile = joinpath(TASOPT.__TASOPTroot__, "IO/default_wide.toml")
+    else
+        println("\n")
+        @info """Requested aircraft type not supported. Selecting Narrow Body Aircraft"""
+        defaultfile = joinpath(TASOPT.__TASOPTroot__, "IO/default_input.toml")
+    end
+    return TOML.parsefile(defaultfile)
+end
 # Convenience functions to convert to SI units
 Speed(x)    = convertSpeed(parse_unit(x)...)
 Distance(x)      = convertDist(parse_unit(x)...)
@@ -85,6 +99,17 @@ ac_descrip = get(data, "Aircraft Description", Dict{})
 name = get(ac_descrip, "name", "Untitled Model")
 description = get(ac_descrip, "description", "---")
 sized = get(ac_descrip, "sized",[false])
+
+# Check if aircraft type exists
+if "aircraft_type" in keys(ac_descrip)
+    default = get_default_input_file(ac_descrip["aircraft_type"])
+    ac_type_fixed = true
+else
+    println("\n")
+    @info """Aircraft Type not specified: Selecting AC type depending on range or payload"""
+    ac_type_fixed = false
+end
+
 #Get number of missions to create data arrays
 mis = read_input("Mission", data, default)
 dmis = default["Mission"]
@@ -97,6 +122,39 @@ para = zeros(Float64, (iatotal, iptotal, nmisx))
 pare = zeros(Float64, (ietotal, iptotal, nmisx))
 
 fuselage = Fuselage()
+
+# Setup mission variables
+ranges = readmis("range")
+parm[imRange, :] .= Distance.(ranges)
+
+if !ac_type_fixed
+    if parm[imRange, 1] <= 2600 * nmi_to_m
+        default = get_default_input_file(0)
+        @info """Setting AC Type based on design range: Regional Aircraft"""
+    elseif parm[imRange, 1] <= 3115 * nmi_to_m
+        default = get_default_input_file(1)
+        @info """Setting AC Type based on design range: Narrow Body Aircraft"""
+    elseif parm[imRange, 1] <= 8500 * nmi_to_m
+        default = get_default_input_file(2)
+        @info """Setting AC Type based on design range: Wide Body Aircraft"""
+    end    
+    ac_type_fixed = true
+end
+
+maxpax = readmis("max_pax")
+pax = readmis("pax")
+despax = pax[1] #Design number of passengers
+if despax > maxpax
+    error("Design mission has higher # of passengers than max passengers for aircraft!")
+end
+
+Wpax =  Force(readmis("weight_per_pax"))
+parm[imWperpax, :] .= Wpax
+parm[imWpay, :] .= pax * Wpax
+parg[igWpaymax] = maxpax * Wpax
+parg[igfreserve] = readmis("fuel_reserves")
+parg[igVne] = Speed(readmis("Vne"))
+parg[igNlift] = readmis("Nlift")
 
 # Setup option variables
 options = read_input("Options", data, default)
@@ -159,21 +217,6 @@ end
 pari[iifwing]  = readfuel("fuel_in_wing")
 pari[iifwcen]  = readfuel("fuel_in_wingcen")
 parg[igrWfmax] = readfuel("fuel_usability_factor")
-
-# Setup mission variables
-ranges = readmis("range")
-parm[imRange, :] .= Distance.(ranges)
-
-maxpax = readmis("max_pax")
-pax = readmis("pax")
-despax = pax[1] #Design number of passengers
-Wpax =  Force(readmis("weight_per_pax"))
-parm[imWperpax, :] .= Wpax
-parm[imWpay, :] .= pax * Wpax
-parg[igWpaymax] = maxpax * Wpax
-parg[igfreserve] = readmis("fuel_reserves")
-parg[igVne] = Speed(readmis("Vne"))
-parg[igNlift] = readmis("Nlift")
 
 ##Takeoff
 takeoff = readmis("Takeoff")


### PR DESCRIPTION
- Changed how read input works
- First reads key in Aircraft Description: `aircraft_type`, then replaces the "default" model for that in case any key missing
- If `aircraft_type` not specified then decides default model based on range:

Regional: range <= 2600 nmi
Narrow Body: range <= 3115 nmi
Wide Body: range <= 8500 nmi

Other changes:
- Added error if design mission pax > maxpax
- Added wide and regional default models to IO folder