### PR TITLE
Better stickfig aircraft plots

### DIFF
--- a/src/IO/outputs.jl
+++ b/src/IO/outputs.jl
@@ -475,7 +475,7 @@ function stickfig(ac::aircraft; ax = nothing, label_fs = 16,
     if ax === nothing
         # plt.style.use(["../miscellaneous/prash.mplstyle"]) # HACK
         fig, ax = plt.subplots(figsize=(8,5), dpi = 300)
-        fig.subplots_adjust(right=0.6)
+        fig.subplots_adjust(right=0.75)
     else
         ax.cla()
     end
@@ -584,7 +584,7 @@ function stickfig(ac::aircraft; ax = nothing, label_fs = 16,
 
     # Annotations
     if annotate_text
-        ax.text(1, 0.8, transform=ax.transAxes, @sprintf("PFEI = %5.3f\nM\$_{cruise}\$ = %.2f\nWMTO = %.1f tonnes\nSpan = %5.1f m\nco    = %5.1f m\n\$ \\Lambda \$ = %.1f\$^\\circ\$\nRfuse = %5.1f m\nL/D = %3.2f",
+        ax.text(1.05, 0.75, transform=ax.transAxes, @sprintf("PFEI = %5.3f\nM\$_{cruise}\$ = %.2f\nWMTO = %.1f t\nSpan = %5.1f m\nco    = %5.1f m\n\$ \\Lambda \$ = %.1f\$^\\circ\$\nRfuse = %5.1f m\nL/D = %3.2f",
         parm[imPFEI], para[iaMach, ipcruise1],parg[igWMTO]/9.81/1000, parg[igb], parg[igco], parg[igsweep], fuselage.layout.radius, para[iaCL, ipcruise1]/para[iaCD, ipcruise1]),
         fontsize = label_fs, ha="left", va="top")
     end
@@ -597,34 +597,17 @@ function stickfig(ac::aircraft; ax = nothing, label_fs = 16,
         ax.text(xend/2, yloc, @sprintf("l = %5.1f m", xend), bbox=Dict("ec"=>"w", "fc"=>"w"), ha="center", va="center", fontsize = 14, zorder = 31)
     end
     # Span annotations:
-    codeD = true
-    codeE = false
-    xcodeD = -2.0
-    xcodeE = -3.5
-        if codeD && annotate_group
-            # ICAO code D 
-            bmaxD = 36
-            ax.vlines(xcodeD, -bmaxD/2, bmaxD/2, lw = 5, alpha = 0.2, color = "y")
-            ax.hlines( bmaxD/2, xcodeD, 40.0, lw = 5, alpha = 0.2, color = "y")
-            ax.hlines(-bmaxD/2, xcodeD, 40.0, lw = 5, alpha = 0.2, color = "y")
-            ax.text(20, bmaxD/2+1, "ICAO Code D/ FAA Group III", color = "y", alpha = 0.8, fontsize = 12, ha="center", va="center")
-        end
-        if codeE && annotate_group
-            # ICAO code E
-            bmaxE = 52
-            ax.vlines(xcodeE, -bmaxE/2, bmaxE/2, lw = 5, alpha = 0.2, color = "b")
-            ax.hlines( bmaxE/2, xcodeE, 40.0, lw = 5, alpha = 0.2, color = "b")
-            ax.hlines(-bmaxE/2, xcodeE, 40.0, lw = 5, alpha = 0.2, color = "b")
-            ax.text(20, bmaxE/2+1, "ICAO Code E/ FAA Group IV", color = "b", alpha = 0.5, fontsize = 12, ha="center", va="center")
-        end
+    groups, bmax = find_aerodrome_code(parg[igbmax]) #Find ICAO and FAA groups as well as max span
+    xcode = -2.0
 
-    if codeE
-        ax.set_ylim(min(-27, -b/2.0), max(27, b/2.0))
-    elseif codeD
-        ax.set_ylim(min(-23, -b/2.0),max(23, b/2.0))
-    else
-        ax.set_ylim(min(-20, -2b/2.0), max(20, b/2.0))
+    if annotate_group
+        ax.vlines(xcode, -bmax/2, bmax/2, lw = 5, alpha = 0.2, color = "y")
+        ax.hlines( bmax/2, xcode, 40.0, lw = 5, alpha = 0.2, color = "y")
+        ax.hlines(-bmax/2, xcode, 40.0, lw = 5, alpha = 0.2, color = "y")
+        ax.text(20, bmax/2+1, "ICAO Code $(groups[1])/ FAA Group $(groups[2])", color = "y", alpha = 0.8, fontsize = 12, ha="center", va="center")
     end
+    ax.set_ylim(-1.2*bmax/2, 1.2*bmax/2)
+
     ax.set_aspect(1)
     ax.set_ylabel("y[m]")
     ax.set_xlabel("x[m]")
@@ -636,6 +619,25 @@ function stickfig(ac::aircraft; ax = nothing, label_fs = 16,
     end
 
     return ax
+end
+
+"""
+    find_aerodrome_code(b)
+
+`find_aerodrome_code` finds the airport code corresponding to a given aircraft wingspan. It returns 
+the codes in the ICAO and FAA formats, as well as the maximum wingspan for these codes.
+"""
+function find_aerodrome_code(b::Float64)
+    max_bs = sort(collect(keys(aerodrome_codes)))
+    idx = 1
+    for cand_maxb in max_bs
+        if b >= cand_maxb 
+            idx += 1
+        end
+    end
+    maxb = max_bs[idx]
+    groups = aerodrome_codes[maxb]
+    return groups, Float64(maxb)
 end
 
 """

--- a/src/misc/constants.jl
+++ b/src/misc/constants.jl
@@ -36,3 +36,13 @@ const seat_layouts = Dict{Int64, Vector{Int64}}(
     15 => [3, 5, 4, 3],
     16 => [3, 5, 5, 3]
 )
+
+const aerodrome_codes = Dict{Int64, Vector{String}}(
+    #max_wingspan => [ICAO code, FAA code]
+    15 => ["A", "I"],
+    24 => ["B", "II"],
+    36 => ["C", "III"],
+    52 => ["D", "IV"],
+    65 => ["E", "V"],
+    80 => ["F", "VI"],
+)

--- a/test/unit_test_outputs.jl
+++ b/test/unit_test_outputs.jl
@@ -31,10 +31,8 @@
         
         TASOPT.stickfig(ac)
         @test 1 == 1
-        TASOPT.high_res_airplane_plot(ac)
-        @test 2 == 2
         TASOPT.plot_details(ac)
-        @test 3 == 3
+        @test 2 == 2
 
     end
 


### PR DESCRIPTION
This PR adds new options to the `stickfig` function that makes stick figure plots of aircraft. It combines it with the alternative function `high_res_airplane_plot`, that produced a very similar-looking plot and had most of the code duplicated. 
These functionality has been implemented:
-The engine is shown again; it was not being rendered due to a data type issue.
-The span, text, and length annotations are now optional; these can be disabled by changing the optional function inputs.
-The ICAO and FAA airport codes are now found automatically for the design maximum span. It fixes a mistake in the previous code, in which ICAO code D was incorrectly compared to FAA group III; it should be ICAO Code C. The plotting area is changed accordingly.
-The text annotations are now shown to the right of the airplane plot, rather than underneath it, which covered most of the text.
-A grid can be optionally added.