### PR TITLE
Added new benchmarks

### DIFF
--- a/docs/src/misc/fordevs.md
+++ b/docs/src/misc/fordevs.md
@@ -9,3 +9,7 @@
     - Look out for `!!! compat` admonishments marking where things will likely change in the future.
     - References to NPSS are currently non-functional. We're working on replacing this functionality efficiently.
 
+!!! tip "Benchmarks"
+    - Examples of aircraft-sizing benchmarking and profiling files are provided in `test/benchmark_sizing.jl`. These can be run after making changes to the code to check if there has been a speed-up or slow-down.
+    - Some individual functions are additionally benchmarked in `test/benchmark_elements.jl`.
+    - Developers can similarly create other benchmarks for new features, models, and functions.

--- a/test/benchmark_elements.jl
+++ b/test/benchmark_elements.jl
@@ -1,28 +1,18 @@
-
 using Pkg, Dates
-import ..TASOPT: __TASOPTindices__
 
 println(today())
 println("Current location $(pwd())")
 using TASOPT
 const aerodynamics = TASOPT.aerodynamics
-include(__TASOPTindices__)
+include(TASOPT.__TASOPTindices__)
 nmisx = 1
-pari = zeros(Int64, iitotal)
-parg = zeros(Float64, igtotal)
-parm = zeros(Float64, (imtotal, nmisx))
-para = zeros(Float64, (iatotal, iptotal, nmisx))
-pare = zeros(Float64, (ietotal, iptotal, nmisx))
-parpt = zeros(Union{Int64, Float64}, ipt_total)
-parmot = zeros(Float64, ite_total)
-pargen = zeros(Float64, ite_total)
 
 using Profile
 using BenchmarkTools
 
-println("Loading TASOPT...")
+println("Loading aircraft model...")
 
-println("Loading input file...")
+include(joinpath(TASOPT.__TASOPTroot__, "../test/default_sized.jl"))
 
 println("\nNotes (from BenchmarkTools Manual):
 - The minimum is a robust estimator for the location parameter of the
@@ -116,13 +106,8 @@ function benchmark_fuseBL()
     $Reyn, $Mach, $fexcr) seconds=30 evals=5
     bench_blax = run(b)
 
-    println("Benchmarking... blax2")
-    b = @benchmarkable aerodynamics.blax2($ndim, $n, $ite, $xi, $bi, $rni, $uinv,
-    $Reyn, $Mach, $fexcr) seconds=30 evals=5
-    bench_blax2 = run(b)
-
     println("Benchmarking... fusebl")
-    b = @benchmarkable aerodynamics.fusebl!($pari, $parg, $para, $ipcruise1) seconds=30 evals=5
+    b = @benchmarkable aerodynamics.fusebl!($fuse, $parm, $para, $ipcruise1) seconds=30 evals=5
     bench_fusebl = run(b)
 
     println("Benchmark results...")
@@ -137,12 +122,6 @@ function benchmark_fuseBL()
     println("blax (FORTRAN on MacPro M2 ~ 1.9 ms)")
     println("---------------------------------------")
     show(stdout, MIME("text/plain"),bench_blax)
-    println(" ")
-
-    println("---------------------------------------")
-    println("blax2 (FORTRAN on MacPro M2 ~ 1.9 ms)")
-    println("---------------------------------------")
-    show(stdout, MIME("text/plain"),bench_blax2)
     println(" ")
 
     println("---------------------------------------")
@@ -356,8 +335,6 @@ function benchmark_gas()
     end
     @benchmark f($100)
 end
-
-include("../Models/ZISA/ZIA_SAF_BLI_10_8_0.647_17.4.mdl")
 
 benchmark_fuseBL()
 benchmark_drag()

--- a/test/benchmark_sizing.jl
+++ b/test/benchmark_sizing.jl
@@ -1,0 +1,45 @@
+using BenchmarkTools
+using Profile
+using ProfileView
+using TASOPT
+
+#----Benchmark all files----
+println("---------------------------------------")
+println("Starting Benchmarks")
+println("---------------------------------------")
+println("Benchmarking DEFAULT aircraft")
+ac = read_aircraft_model(joinpath(TASOPT.__TASOPTroot__, "IO/default_input.toml")) # MODIFY <path> appropriately
+res1 = @benchmark size_aircraft!(ac, iter=50; printiter = false) seconds=30 samples=5
+
+println("Benchmarking REGIONAL aircraft")
+ac = read_aircraft_model(joinpath(TASOPT.__TASOPTroot__, "../example/example_regional.toml")) # MODIFY <path> appropriately
+res2 = @benchmark size_aircraft!(ac, iter=50; printiter = false) seconds=30 samples=5
+
+println("Benchmarking WIDEBODY aircraft")
+ac = read_aircraft_model(joinpath(TASOPT.__TASOPTroot__, "../example/example_widebody.toml")) # MODIFY <path> appropriately
+res3 = @benchmark size_aircraft!(ac, iter=50; printiter = false) seconds=30 samples=5
+
+println("Benchmarking HYDROGEN aircraft")
+ac = read_aircraft_model(joinpath(TASOPT.__TASOPTroot__, "../example/cryo_input.toml")) # MODIFY <path> appropriately
+res4 = @benchmark size_aircraft!(ac, iter=50; printiter = false) seconds=30 samples=5
+
+println("---------------------------------------")
+println("Benchmark Results")
+println("---------------------------------------")
+println("DEFAULT aircraft")
+display(res1)
+println("REGIONAL aircraft")
+display(res2)
+println("WIDEBODY aircraft")
+display(res3)
+println("HYDROGEN aircraft")
+display(res4)
+
+#----Profile the code----
+#Select aircraft file to run profile with
+ac = read_aircraft_model(joinpath(TASOPT.__TASOPTroot__, "IO/default_input.toml")) 
+Profile.clear()
+@profile size_aircraft!(ac, iter=50; printiter = false)
+#Profile.print() #Print the profile results (prints large set of results)
+
+ProfileView.view() #View the profile


### PR DESCRIPTION
This PR revives the old benchmark functions for the fuselage and drag calculations (now in `benchmark_elements.jl`). It also introduces functions to benchmark the aircraft sizing for all four example models (default, regional, widebody and cryo). 