### PR TITLE
max payload tweak + follow-ups

### DIFF
--- a/src/IO/read_input.jl
+++ b/src/IO/read_input.jl
@@ -152,7 +152,7 @@ if any(maxpax .< pax)
     "\n Payloads listed [in pax] = "*string(pax))
 end
 if any(exitlimit .< pax)
-    error("One or more missions have higher payload than the prescribed exit limit!:"*
+    error("One or more missions have higher passenger counts than the prescribed exit limit!:"*
     "\n Exit limit [in pax] = "*string(exitlimit)*
     "\n Payloads listed [in pax] = "*string(pax))
 end

--- a/src/IO/read_input.jl
+++ b/src/IO/read_input.jl
@@ -145,10 +145,16 @@ maxpax = readmis("max_payload_in_pax_equivalent") #This represents the maximum a
 pax = readmis("pax")
 exitlimit = readmis("exit_limit")
 despax = pax[1] #Design number of passengers
-if despax > maxpax
-    error("Design mission has higher payload weight than maximum aircraft payload!")
-elseif despax > exitlimit
-    error("Design mission has higher # of passengers than the exit limit!")
+
+if any(maxpax .< pax)
+    error("One or more missions have higher payload than prescribed maximum aircraft payload!:"*
+    "\n Max Payload [in pax] = "*string(maxpax)*
+    "\n Payloads listed [in pax] = "*string(pax))
+end
+if any(exitlimit .< pax)
+    error("One or more missions have higher payload than the prescribed exit limit!:"*
+    "\n Exit limit [in pax] = "*string(exitlimit)*
+    "\n Payloads listed [in pax] = "*string(pax))
 end
 
 Wpax =  Force(readmis("weight_per_pax"))


### PR DESCRIPTION
Edit in the `read_input` checks to include off-design missions in the max_payload exit_limit checks

context: discussed with @speth and thought about this framing vs. a max_payload in tons. decided against it since this is equivalent, though all of this needs documenting

