### PR TITLE
example flag style propagation + minor corrections

### DIFF
--- a/src/sizing/wsize.jl
+++ b/src/sizing/wsize.jl
@@ -1209,7 +1209,7 @@ function wsize(ac; itermax=35,
             #Find and store maximum HX outer diameter to check fit in engine 
             for HX in HXs
                 parg[igdHXmax] = 0.0 #restart diameter
-                if HX.HXgeom.fconc #If HX is in the core
+                if HX.HXgeom.flag_is_concentric #If HX is in the core
                     parg[igdHXmax] = max(parg[igdHXmax], HX.HXgeom.D_o)
                 end
             end

--- a/src/structures/size_cabin.jl
+++ b/src/structures/size_cabin.jl
@@ -168,7 +168,7 @@ This function can be used to place the passenger decks inside the fuselage. It w
 cabins. It returns the angular position of each deck with respect to the center of the upper bubble.
 !!! details "🔃 Inputs and Outputs"
     **Inputs:**
-    - `Rfuse::Bool`: flag to indicate whether aircraft is a double decker
+    - `fdoubledecker::Bool`: flag to indicate whether aircraft is a double decker
     - `Rfuse::Float64`: fuselage exterior radius (m)
     - `dRfuse::Float64`: vertical shift of downward bubble (m)
     - `θ1::Float64`: required in some cases; angle of main floor wrt upper bubble center (rad)

--- a/test/unit_test_heat_exchanger.jl
+++ b/test/unit_test_heat_exchanger.jl
@@ -31,9 +31,9 @@
         HXgas.alpha_p = [0.7532, 0.2315, 0.0006, 0.0020, 0.0127]
         HXgas.igas_c = 40
 
-        HXgeom.fconc = true
-        HXgeom.frecirc = false
-        HXgeom.fshaft = false
+        HXgeom.flag_is_concentric = true
+        HXgeom.flag_recirculates = false
+        HXgeom.flag_has_shaft = false
         HXgeom.D_i = 0.564
         HXgeom.l = 0.6084530646014857 #tube length
         HXgeom.n_stages = 4
@@ -86,8 +86,8 @@
         HXgas.alpha_p = [0.7532, 0.2315, 0.0006, 0.0020, 0.0127]
         HXgas.igas_c = 40
 
-        HXgeom.fconc = true
-        HXgeom.frecirc = false
+        HXgeom.flag_is_concentric = true
+        HXgeom.flag_recirculates = false
         HXgeom.D_i = 0.564
         HXgeom.t = 0.03e-2 #m, wall thicknesss
         HXgeom.tD_o = 0.004760326082769499
@@ -132,8 +132,8 @@
         HXgas.alpha_p = [0.7532, 0.2315, 0.0006, 0.0020, 0.0127]
         HXgas.igas_c = 40
 
-        HXgeom.fconc = true
-        HXgeom.frecirc = false
+        HXgeom.flag_is_concentric = true
+        HXgeom.flag_recirculates = false
         HXgeom.D_i = 0.564
         HXgeom.l = 0.6084530646014857 #tube length
         HXgeom.xl_D = 1
@@ -151,7 +151,7 @@
 
         A_cs = HXgas.mdot_p / (ρ_p_in * Vp_in) #Cross-sectional area of freestream
 
-        if HXgeom.fconc #Flow is concentric
+        if HXgeom.flag_is_concentric #Flow is concentric
             D_i = HXgeom.D_i
             D_o = sqrt(4 * (A_cs + pi * D_i^2 / 4) / pi) #Core outer diameter
 
@@ -200,8 +200,8 @@
         HXgas.alpha_p = [0.7532, 0.2315, 0.0006, 0.0020, 0.0127]
         HXgas.igas_c = 40
 
-        HXgeom.fconc = false
-        HXgeom.frecirc = true
+        HXgeom.flag_is_concentric = false
+        HXgeom.flag_recirculates = true
         HXgeom.t = 0.03e-2 #m, wall thicknesss
         HXgeom.xl_D = 1
         HXgeom.Rfp = 0.01*0.1761 #Engine exhaust air fouling resistance, m^2*K/W
@@ -218,7 +218,7 @@
 
         A_cs = HXgas.mdot_p / (ρ_p_in * Vp_in) #Cross-sectional area of freestream
 
-        if HXgeom.fconc #Flow is concentric
+        if HXgeom.flag_is_concentric #Flow is concentric
             D_i = HXgeom.D_i
             D_o = sqrt(4 * (A_cs + pi * D_i^2 / 4) / pi) #Core outer diameter
 


### PR DESCRIPTION
Noting that the conversion of `pari` is near(ish), a consistent flag syntax would be ideal. 

@speth suggested a convention of `<verb>_<subject>` like `is_laminar` or `has_shaft` for Boolean parameters, PLUS a string-based option selection for parameters that have more options (e.g `icool` can be `opt_cooling` which will be under `engine`). I would also vote to add a prefix for flags, e.g., `flag_is_laminar`, for ease of searching and identification in the codebase.

Thoughts/objections on this @everyone (@aditeyashukla @ngomezve @askprash )? 
Making sure we all agree before trying to push beyond this sample `HXfun.jl`

