### PR TITLE
Update CI and version requirements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
           version:          #as defined by setup-julia - https://github.com/julia-actions/setup-julia?tab=readme-ov-file#examples
-               - '1.9'      #initial version for tasopt dev
+               - '1.11'      #latest stable release as of 12/2024
                - 'lts'      #long-term-support, julia 1.10 as of 10/2024
           os: 
               - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TASOPT"
 uuid = "22dd2482-b234-48ce-b849-20a4e029c823"
 authors = ["Prashanth Prakash <prash@mit.edu> and contributors"]
-version = "3.0.0-beta"
+version = "3.0.0-beta.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
@@ -27,4 +27,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-julia = ">=1.8.4"
+julia = ">=1.10"


### PR DESCRIPTION
Drop testing of old julia version v1.9 - outdated version given the LTS is already at  v1.10 and the latest stable release is v1.11.2