### PR TITLE
Update CI codecov keyword

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info


### PR DESCRIPTION
Uses `files` instead of `file`. See [here.](https://github.com/codecov/codecov-action#:~:text=file%20(this%20has,of%20plugins))