### PR TITLE
Speeding up tank calculations

### DIFF
--- a/example/cryo_input.toml
+++ b/example/cryo_input.toml
@@ -58,7 +58,6 @@ name = "TASOPT Model with cryo fuel and HX"
     weld_efficiency = 0.9 
     ullage_fraction = 0.05 #minimum ullage fraction at tank venting pressure
     heat_leak_factor = 1.3 #Factor to account for heat leakage through structural elements, piping, etc (qfac > 1)
-    SL_temperature_for_tank = "288.2 K"
 
     #Tank pressure design parameters
     pressure_rise_factor = 2.0 #Factor to account for stratification in homogenous tank model (pfac >= 1)

--- a/example/defaults/default_input.toml
+++ b/example/defaults/default_input.toml
@@ -65,7 +65,6 @@
     weld_efficiency = 0.9 
     ullage_fraction = 0.05 #minimum ullage fraction at tank venting pressure
     heat_leak_factor = 1.3 #Factor to account for heat leakage through structural elements, piping, etc (qfac > 1)
-    SL_temperature_for_tank = "288.2 K"
 
     #Tank pressure design parameters
     pressure_rise_factor = 2.0 #Factor to account for stratification in homogenous tank model (pfac >= 1)

--- a/example/defaults/default_regional.toml
+++ b/example/defaults/default_regional.toml
@@ -61,7 +61,6 @@
     weld_efficiency = 0.9 
     ullage_fraction = 0.05 #minimum ullage fraction at tank venting pressure
     heat_leak_factor = 1.3 #Factor to account for heat leakage through structural elements, piping, etc (qfac > 1)
-    SL_temperature_for_tank = "288.2 K"
 
     #Tank pressure design parameters
     pressure_rise_factor = 2.0 #Factor to account for stratification in homogenous tank model (pfac >= 1)

--- a/example/defaults/default_wide.toml
+++ b/example/defaults/default_wide.toml
@@ -63,7 +63,6 @@
     weld_efficiency = 0.9 
     ullage_fraction = 0.05 #minimum ullage fraction at tank venting pressure
     heat_leak_factor = 1.3 #Factor to account for heat leakage through structural elements, piping, etc (qfac > 1)
-    SL_temperature_for_tank = "288.2 K"
 
     #Tank pressure design parameters
     pressure_rise_factor = 2.0 #Factor to account for stratification in homogenous tank model (pfac >= 1)

--- a/src/IO/read_input.jl
+++ b/src/IO/read_input.jl
@@ -464,6 +464,11 @@ if !(has_wing_fuel) #If fuel is stored in fuselage
     fuse_tank.qfac = readfuel_storage("heat_leak_factor")
     fuse_tank.pfac = readfuel_storage("pressure_rise_factor")
 
+    for (i,altTO) in enumerate(parm[imaltTO, :]/1e3)
+        T_std, _, _, _, _ = atmos(altTO)
+        push!(fuse_tank.TSLtank, parm[imT0TO,i] - T_std + Tref)
+    end
+    
     has_vacuum = TASOPT.CryoTank.check_vacuum(fuse_tank.material_insul) #flag to check if an outer vessel is needed
 
     if has_vacuum #If tank is double-walled

--- a/src/IO/read_input.jl
+++ b/src/IO/read_input.jl
@@ -462,7 +462,6 @@ if !(has_wing_fuel) #If fuel is stored in fuselage
     fuse_tank.ew = readfuel_storage("weld_efficiency")
     fuse_tank.ullage_frac = readfuel_storage("ullage_fraction")
     fuse_tank.qfac = readfuel_storage("heat_leak_factor")
-    fuse_tank.TSLtank = Temp(readfuel_storage("SL_temperature_for_tank"))
     fuse_tank.pfac = readfuel_storage("pressure_rise_factor")
 
     has_vacuum = TASOPT.CryoTank.check_vacuum(fuse_tank.material_insul) #flag to check if an outer vessel is needed

--- a/src/cryo_tank/CryoTank.jl
+++ b/src/cryo_tank/CryoTank.jl
@@ -12,6 +12,7 @@ using NLsolve
 using Roots
 using NLopt
 using DifferentialEquations
+using StaticArrays
 
 import ..TASOPT: __TASOPTindices__, __TASOPTroot__, compare_strings
 

--- a/src/cryo_tank/pressure.jl
+++ b/src/cryo_tank/pressure.jl
@@ -19,13 +19,13 @@ end
 """
 Structure with inputs for tank pressure calculation.
 """
-struct tank_inputs
+struct tank_inputs{F1, F2, F3}
     """Heat rate as a function of time (W)"""
-    Q_calc::Function
+    Q_calc::F1
     """Work rate as a function of time (W)"""
-    W_calc::Function
+    W_calc::F2
     """Liquid mass flow rate as a function of time (kg/s)"""
-    mdot_calc::Function
+    mdot_calc::F3
 end
 
 """

--- a/src/cryo_tank/pressure.jl
+++ b/src/cryo_tank/pressure.jl
@@ -178,7 +178,7 @@ function TankDerivatives(t::Float64, y::AbstractVector{Float64}, u::tank_inputs,
 
     dp_dt = dpdt(mix_current, Q, W, mdot, xout, mdot_vent, xvent, V, α)
     dβ_dt = dβdt(mix_current, dp_dt, mdot_tot, V) #dβ/dt
-    #Calculate derivates and store them
+    #Calculate derivatives and store them
     dydt = @SVector[
         dp_dt, 
         dβ_dt,

--- a/src/cryo_tank/tankWmech.jl
+++ b/src/cryo_tank/tankWmech.jl
@@ -7,7 +7,7 @@
       **Inputs:**
       - `fuse::Fuselage`: fuselage object.
       - `fuse_tank::fuselage_tank`: fuselage tank object.
-      - `t_cond::Float64`: Vector with tank isulation layer thickness. Provided separately from fuse_tank as it changes during 
+      - `t_cond::Vector{Float64}`: Vector with tank isulation layer thickness. Provided separately from fuse_tank as it changes during 
       non-linear solve process.
 
       **Outputs:**
@@ -35,7 +35,7 @@ function size_inner_tank(fuse::Fuselage, fuse_tank::fuselage_tank, t_cond::Vecto
       #---------------------------------
       # Unpack parameters in fuse_tank
       #---------------------------------
-      Rfuse = fuse.layout.radius
+      Rfuse = structures.Rfuse(fuse)
       fuse_cs = fuse.layout.cross_section #Fuselage cross section
 
       Wfuel = fuse_tank.Wfuelintank
@@ -119,11 +119,11 @@ function size_inner_tank(fuse::Fuselage, fuse_tank::fuselage_tank, t_cond::Vecto
       # Insulation weight
       N = length(t_cond) #Number of insulation layers
       #Initialize storage vectors
-      Vcyl_insul = zeros(N)
-      Winsul = zeros(N)
-      Shead_insul = zeros(N + 1) #add one for first (tank wall) surface 
-      Vhead_insul = zeros(N)
-      rho_insul = zeros(N)
+      Vcyl_insul = zeros(Float64, N)
+      Winsul = zeros(Float64, N)
+      Shead_insul = zeros(Float64, N + 1) #add one for first (tank wall) surface 
+      Vhead_insul = zeros(Float64, N)
+      rho_insul = zeros(Float64, N)
       L = Lhead + tskin #Length of ellipsoid semi-minor axis
 
       #Assemble vector with layer densities

--- a/src/cryo_tank/tankWmech.jl
+++ b/src/cryo_tank/tankWmech.jl
@@ -340,6 +340,9 @@ This function can be used to calculate the bending moment distribution in a stif
 It applies Eqs. (7.4) and (7.5) in Barron (1985) to find the bending moment distribution. The function returns the
 maximum value of ``k = 2πM/(WR)`` on the ring's circumference.
 
+Note: An attempt was made to use the NLopt.jl package to find the maximum value of k, 
+but this was more expensive and less robust than the brute-force approach.
+
 !!! details "🔃 Inputs and Outputs"
     **Inputs:**
     - `θ::Float64`: angular position of tank supports, measured from the bottom of the tank (rad).

--- a/src/cryo_tank/tankWthermal.jl
+++ b/src/cryo_tank/tankWthermal.jl
@@ -39,7 +39,7 @@ This structure stores the material and thermal properties of a cryogenic tank in
 end
 
 """
-      tankWthermal(fuse::Fuselage, fuse_tank::fuselage_tank, z::Float64, Mair::Float64, xftank::Float64, ifuel::Int64)
+      tankWthermal(fuse::Fuselage, fuse_tank::fuselage_tank, z::Float64, TSL::Float64, Mair::Float64, xftank::Float64, ifuel::Int64)
 
 `tankWthermal` calculates the heat rate to a cryogenic tank for a given insulation thickness.
 
@@ -52,6 +52,7 @@ for a given insulation thickness
       - `fuse::Fuselage`: fuselage object.
       - `fuse_tank::fuselage_tank`: fuselage tank object.
       - `z::Float64`: flight altitude (m)
+      - `TSL::Float64`: sea-level temperature (K)
       - `Mair::Float64`: external air Mach number
       - `xftank::Float64`: longitudinal coordinate of fuel tank centroid from nose (m)
       - `ifuel::Int64`: fuel index.
@@ -61,8 +62,7 @@ for a given insulation thickness
 
 See [here](@ref fueltanks).
 """
-function tankWthermal(fuse::Fuselage, fuse_tank::fuselage_tank, z::Float64, Mair::Float64, xftank::Float64, ifuel::Int64)
-      TSL = fuse_tank.TSLtank
+function tankWthermal(fuse::Fuselage, fuse_tank::fuselage_tank, z::Float64, TSL::Float64, Mair::Float64, xftank::Float64, ifuel::Int64)
       qfac = fuse_tank.qfac
       t_cond = fuse_tank.t_insul
       Tfuel = fuse_tank.Tfuel

--- a/src/cryo_tank/tanksize.jl
+++ b/src/cryo_tank/tanksize.jl
@@ -41,7 +41,7 @@ function tanksize!(ac, imission::Int64 = 1)
         Wfuelintank = fuse_tank.Wfuelintank #weight of fuel in tank
         Tfuel = fuse_tank.Tfuel #fuel temperature
         sizes_insulation = fuse_tank.sizes_insulation #Boolean for whether to size for a boiloff rate
-        TSL = Tref + ac.parm[imDeltaTatm, imission] #sea-level temperature for tank design
+        TSL = fuse_tank.TSLtank[imission] #sea-level temperature for tank design
 
         #------Size insulation, if requested------
         if sizes_insulation #If insulation is sized for a given boiloff rate

--- a/src/cryo_tank/tanksize.jl
+++ b/src/cryo_tank/tanksize.jl
@@ -80,7 +80,12 @@ function tanksize!(ac, imission::Int64 = 1)
         thickness_insul = sum(t_cond)
         
         #Evaluate tank weight
-        Winnertank, Winsul_sum, Vfuel, _, Rinnertank, l_inner, lcyl1 = size_inner_tank(fuse, fuse_tank, fuse_tank.t_insul)
+        Winnertank, Winsul_sum, Vfuel, Shead_insul, Rinnertank, l_inner, lcyl1 = size_inner_tank(fuse, fuse_tank, fuse_tank.t_insul)
+        #Store in fuse_tank
+        fuse_tank.Rinnertank = Rinnertank 
+        fuse_tank.l_inner = l_inner 
+        fuse_tank.l_cyl_inner = lcyl1 
+        fuse_tank.Shead_insul = Shead_insul 
 
         has_vacuum = check_vacuum(fuse_tank.material_insul) #check if there is a vacuum layer
 

--- a/src/cryo_tank/tanktools.jl
+++ b/src/cryo_tank/tanktools.jl
@@ -206,12 +206,12 @@ function analyze_TASOPT_tank(ac::aircraft, t_hold_orig::Float64 = 0.0, t_hold_de
     
     TSL = ac.fuse_tank.TSLtank[im]  #sea-level temperature for tank analysis
     #Precompute heat transfer rate at each mission point for speed
-    Qs_points = calc_Q_points(ac.fuselage, ac.fuse_tank, ac.options.ifuel, ac.parg, para_alt, TSL)
+    Qs_points = calc_Q_points(ac.fuselage, ac.fuse_tank, ac.options.ifuel, ac.parg, para_alt, TSL::Float64)
 
     #Define functions for heat and fuel burn profiles through mission 
-    Q_calc(t) = find_Q_time_interp(t, para_alt, Qs_points)
-    W_calc(t) = 0.0
-    mdot_calc(t) = find_mdot_time(t, ac.fuse_tank.tank_count, ac.parg, para_alt, pare_alt)
+    Q_calc(t::Float64) = find_Q_time_interp(t, para_alt, Qs_points)
+    W_calc(t::Float64) = 0.0
+    mdot_calc(t::Float64) = find_mdot_time(t, ac.fuse_tank.tank_count, ac.parg, para_alt, pare_alt)
 
     #Store profiles in input struct
     u = tank_inputs(Q_calc, W_calc, mdot_calc)

--- a/src/cryo_tank/tanktools.jl
+++ b/src/cryo_tank/tanktools.jl
@@ -204,7 +204,7 @@ function analyze_TASOPT_tank(ac::aircraft, t_hold_orig::Float64 = 0.0, t_hold_de
     pare_alt = zeros(size(pare_orig, 1), size(pare_orig, 2) + 3)
     pare_alt[:, 3:(iptotal + 2)] .= pare_orig
     
-    TSL = Tref + ac.parm[imDeltaTatm, im] #sea-level temperature for tank analysis
+    TSL = ac.fuse_tank.TSLtank[im]  #sea-level temperature for tank analysis
     #Precompute heat transfer rate at each mission point for speed
     Qs_points = calc_Q_points(ac.fuselage, ac.fuse_tank, ac.options.ifuel, ac.parg, para_alt, TSL)
 

--- a/src/cryo_tank/tanktools.jl
+++ b/src/cryo_tank/tanktools.jl
@@ -16,9 +16,10 @@ model with fuselage fuel tanks.
 function find_mdot_time(t::Float64, tank_count::Int64, parg::Vector{Float64}, para::Array{Float64}, pare::Array{Float64})
 
     #Mass flow rate out of tank is total mass flow to engines divided by number of tanks
-    mdots = pare[ieff, :] .* pare[iemcore, :] .* parg[igneng] / tank_count
+    scale = parg[igneng] / tank_count
+    mdots = scale .* pare[ieff, :] .* pare[iemcore, :]
 
-    times = para[iatime,:]
+    times = @view para[iatime,:]
 
     # Handle cases where t is exactly one of the sample points
     if t in times
@@ -92,7 +93,7 @@ at each mission point for speed.
     - `Q::Float64`: heat transfer rate (W)
 """
 function find_Q_time_interp(t::Float64, para::Array{Float64}, Qs::Vector{Float64})
-    times = para[iatime,:]
+    times = @view para[iatime,:]
 
     # Handle cases where t is exactly one of the sample points
     if t in times
@@ -135,7 +136,7 @@ function find_Q_time(t::Float64, fuse::Fuselage, fuse_tank::fuselage_tank, fuelt
         xftank = parg[igxftank]
     end
     
-    times = para[iatime,:,1]
+    times = @view para[iatime,:,1]
 
     Q = 0.0
     for ip = 1:(length(times)-1)
@@ -164,12 +165,12 @@ function find_Q_time(t::Float64, fuse::Fuselage, fuse_tank::fuselage_tank, fuelt
 end
 
 """
-    analyze_TASOPT_tank(ac_orig, t_hold_orig::Float64 = 0.0, t_hold_dest::Float64 = 0.0, N::Int64 = 50)
+    analyze_TASOPT_tank(ac, t_hold_orig::Float64 = 0.0, t_hold_dest::Float64 = 0.0, N::Int64 = 50)
 
 This function analyses the evolution in time of a cryogenic tank inside a TASOPT aircraft model.
 !!! details "🔃 Inputs and Outputs"
     **Inputs:**
-    - `ac_orig::aicraft`: TASOPT aircraft model
+    - `ac::aicraft`: TASOPT aircraft model
     - `t_hold_orig::Float64`: hold at origin (s)
     - `t_hold_dest::Float64`: hold at destination (s)
     - `im::Int64`: mission index
@@ -185,23 +186,23 @@ This function analyses the evolution in time of a cryogenic tank inside a TASOPT
     - `Mvents::Vector{Float64}`: vector with cumulative mass that has been vented (kg)
     - `mdots::Vector{Float64}`: vector with fuel mass flow rate to engines (kg/s)
     - `Qs::Vector{Float64}`: vector with heat rate to tank (W)
-    
 """
-function analyze_TASOPT_tank(ac_orig::aircraft, t_hold_orig::Float64 = 0.0, t_hold_dest::Float64 = 0.0, im::Int64 = 1)
-    ac = deepcopy(ac_orig) #Deepcopy original struct to avoid modifying it
+function analyze_TASOPT_tank(ac::aircraft, t_hold_orig::Float64 = 0.0, t_hold_dest::Float64 = 0.0, im::Int64 = 1)
+    para_orig = ac.para[:, :, im]
+    pare_orig = ac.pare[:, :, im]
 
     #Modify aircraft with holding times
-    para_alt = zeros(size(ac.para)[1], size(ac.para)[2] + 3)
-    ac.para[iatime, :, im] .= ac.para[iatime, :, im] .- minimum(ac.para[iatime, :, im])
-    para_alt[:, 3:(iptotal + 1)] .= ac.para[:, 1:(size(ac.para)[2] - 1), im] #Do not copy iptest
-    para_alt[iatime, 2:(iptotal + 1)] .= para_alt[iatime, 2:(iptotal + 1)] .+ t_hold_orig #Apply hold at origin
+    para_alt = zeros(size(para_orig, 1), size(para_orig, 2) + 3)
+    para_alt[:, 3:(iptotal + 1)] .= para_orig[:, 1:(size(para_orig, 2) - 1)]
+    # Apply time shift logic
+    para_alt[iatime, 2:(iptotal + 1)] .+= t_hold_orig
     para_alt[iatime, 1] = 0.0
-    Np = size(para_alt)[2]
+    Np = size(para_alt, 2)
     para_alt[iatime, Np-1] = maximum(para_alt[iatime, :])
-    para_alt[iatime, Np] = para_alt[iatime, Np-1] + t_hold_dest #Apply hold at destination
-
-    pare_alt = zeros(size(ac.pare)[1], size(ac.pare)[2] + 3)
-    pare_alt[:, 3:(iptotal + 2)] .= ac.pare[:,:, im]
+    para_alt[iatime, Np] = para_alt[iatime, Np-1] + t_hold_dest
+    
+    pare_alt = zeros(size(pare_orig, 1), size(pare_orig, 2) + 3)
+    pare_alt[:, 3:(iptotal + 2)] .= pare_orig
     
     #Precompute heat transfer rate at each mission point for speed
     Qs_points = calc_Q_points(ac.fuselage, ac.fuse_tank, ac.options.ifuel, ac.parg, para_alt)
@@ -246,7 +247,7 @@ function analyze_TASOPT_tank(ac_orig::aircraft, t_hold_orig::Float64 = 0.0, t_ho
     ODEparams = (u, params)
 
     #Integrate profiles across mission
-    y0 = [p0, β0, M0, 0.0, 0.0, 0.0] #Initial states
+    y0 = @SVector [p0, β0, M0, 0.0, 0.0, 0.0] #Initial states
 
     tspan = (0.0, para_alt[iatime,end]) #start and end times
 

--- a/src/data_structs/aircraft.jl
+++ b/src/data_structs/aircraft.jl
@@ -40,12 +40,12 @@ Refer to the docs for a summary of the main `struct`s.
     description::String = "Indescribable"
     options::TASOPT.Options
 
-    parg::AbstractVector{Float64}
-    parm::AbstractArray{Float64}
-    para::AbstractArray{Float64}
-    pare::AbstractArray{Float64}
+    parg::Vector{Float64}
+    parm::Array{Float64, 2}
+    para::Array{Float64, 3}
+    pare::Array{Float64, 3}
     
-    is_sized::AbstractVector{Bool} = [false]
+    is_sized::Vector{Bool} = [false]
 
     fuselage::Fuselage = Fuselage()
     fuse_tank::fuselage_tank = fuselage_tank()

--- a/src/data_structs/fuselage.jl
+++ b/src/data_structs/fuselage.jl
@@ -71,6 +71,8 @@ function dx_cabin(fuse::Fuselage)
     return fuse.layout.x_end_cylinder - fuse.layout.x_start_cylinder
 end
 
+Rfuse(fuse::Fuselage) = Rfuse(fuse.layout.cross_section)
+
 # fuselage = Fuselage()
 
 

--- a/src/data_structs/fuselage_tank.jl
+++ b/src/data_structs/fuselage_tank.jl
@@ -55,6 +55,8 @@ $TYPEDFIELDS
     t_hold_orig::Float64 = 0.0
     """Arrival hold time (s)"""
     t_hold_dest::Float64 = 0.0
+    """Sea-level temperature for tank design (K)"""
+    TSLtank::Vector{Float64} = []
 
     """Liquid fuel density (kg/m^3)"""
     rhofuel::Float64 = 0.0

--- a/src/data_structs/fuselage_tank.jl
+++ b/src/data_structs/fuselage_tank.jl
@@ -55,8 +55,6 @@ $TYPEDFIELDS
     t_hold_orig::Float64 = 0.0
     """Arrival hold time (s)"""
     t_hold_dest::Float64 = 0.0
-    """Sea-level temperature used to design tank (K)"""
-    TSLtank::Float64 = 0.0
 
     """Liquid fuel density (kg/m^3)"""
     rhofuel::Float64 = 0.0

--- a/src/data_structs/fuselage_tank.jl
+++ b/src/data_structs/fuselage_tank.jl
@@ -23,6 +23,14 @@ $TYPEDFIELDS
     material_insul::Vector{ThermalInsulator} = []
     """Vector with insulation layer design indices"""
     iinsuldes::Vector{Int64} = []
+    """Length of cylindrical portion of tank (m)"""
+    l_cyl_inner::Float64 = 0.0
+    """Length of inner tank (m)"""
+    l_inner::Float64 = 0.0
+    """Inner tank radius (m)"""
+    Rinnertank::Float64 = 0.0
+    """Vector with surface areas of insulation tank heads (m^2)"""
+    Shead_insul::Vector{Float64} = []
 
     """Inner vessel material"""
     inner_material::StructuralAlloy = StructuralAlloy("Al-2219-T87")

--- a/src/data_structs/fuselage_tank.jl
+++ b/src/data_structs/fuselage_tank.jl
@@ -18,11 +18,11 @@ $TYPEDFIELDS
     clearance_fuse::Float64 = 0.0
 
     """Vector with insulation layer thickness (m)"""
-    t_insul::Vector{Float64} = []
+    t_insul::Vector{Float64} = Float64[]
     """Vector with insulation materials"""
-    material_insul::Vector{ThermalInsulator} = []
+    material_insul::Vector{ThermalInsulator} = Float64[]
     """Vector with insulation layer design indices"""
-    iinsuldes::Vector{Int64} = []
+    iinsuldes::Vector{Int64} = Float64[]
     """Length of cylindrical portion of tank (m)"""
     l_cyl_inner::Float64 = 0.0
     """Length of inner tank (m)"""
@@ -30,7 +30,7 @@ $TYPEDFIELDS
     """Inner tank radius (m)"""
     Rinnertank::Float64 = 0.0
     """Vector with surface areas of insulation tank heads (m^2)"""
-    Shead_insul::Vector{Float64} = []
+    Shead_insul::Vector{Float64} = Float64[]
 
     """Inner vessel material"""
     inner_material::StructuralAlloy = StructuralAlloy("Al-2219-T87")
@@ -41,7 +41,7 @@ $TYPEDFIELDS
     """Angular location of inner vessel stiffeners"""
     theta_inner::Float64 = 0.0
     """Vector with angular location of outer vessel stiffeners"""
-    theta_outer::Vector{Float64} = []
+    theta_outer::Vector{Float64} = Float64[]
     """Number of intermediate stiffeners in outer vessel"""
     Ninterm::Float64 = 1.0
     

--- a/src/data_structs/layout.jl
+++ b/src/data_structs/layout.jl
@@ -87,6 +87,9 @@ function Base.getproperty(obj::MultiBubble, sym::Symbol)
     end
 end  # function Base.getproperty
 
+Rfuse(cs::SingleBubble) = cs.radius
+Rfuse(cs::MultiBubble) = cs.radius
+
 """
 $TYPEDEF
 

--- a/src/engine/gascalc.jl
+++ b/src/engine/gascalc.jl
@@ -1110,16 +1110,21 @@ viscosity, thermal conductivity, specific heat, and Prandtl number.
 """
 function gasPr(gas, T)
       #TODO: replace with new gas model
-      if (gas == "air")
+      if (gas == "air") || (gas == "air_simple")
             μ0 = 1.716e-5
             S_μ = 111
             K0 = 0.0241
             S_k = 194
             T0 = 273
 
-            alpha = [0.7532, 0.2315, 0.0006, 0.0020, 0.0127, 0.0]
-            nair = 5
-            s, dsdt, ht, dhdt, cp, R = gassum(alpha, nair, T)
+            if gas == "air" 
+                  alpha = [0.7532, 0.2315, 0.0006, 0.0020, 0.0127, 0.0]
+                  nair = 5
+                  s, dsdt, ht, dhdt, cp, R = gassum(alpha, nair, T)
+            else #"air_simple"
+                  R = 287.1 
+                  cp = 1005.0 #Just return constant cp
+            end
 
       elseif (gas == "co2")
             μ0 = 1.370e-5

--- a/src/mission/fly_mission.jl
+++ b/src/mission/fly_mission.jl
@@ -43,7 +43,6 @@ function fly_mission!(ac, imission = 1; itermax = 35, initializes_engine = true)
     T_std,_,_,_,_ = atmos(altTO/1e3)
     ΔTatmos = parm[imT0TO] - T_std #temperature difference such that T(altTO) = T0TO
     parm[imDeltaTatm] = ΔTatmos
-    fuse_tank.TSLtank = Tref + ΔTatmos #store sea-level temperature in tank struct
 
     # Calculates surface velocities, boundary layer, wake 
     fuselage_drag!(fuse, parm, para, ipcruise1)

--- a/test/benchmark_sizing.jl
+++ b/test/benchmark_sizing.jl
@@ -12,11 +12,11 @@ ac = read_aircraft_model(joinpath(TASOPT.__TASOPTroot__, "../example/defaults/de
 res1 = @benchmark size_aircraft!(ac, iter=50; printiter = false) seconds=30 samples=5
 
 println("Benchmarking REGIONAL aircraft")
-ac = read_aircraft_model(joinpath(TASOPT.__TASOPTroot__, "../example/example_regional.toml")) # MODIFY <path> appropriately
+ac = read_aircraft_model(joinpath(TASOPT.__TASOPTroot__, "../example/defaults/default_regional.toml")) # MODIFY <path> appropriately
 res2 = @benchmark size_aircraft!(ac, iter=50; printiter = false) seconds=30 samples=5
 
 println("Benchmarking WIDEBODY aircraft")
-ac = read_aircraft_model(joinpath(TASOPT.__TASOPTroot__, "../example/example_widebody.toml")) # MODIFY <path> appropriately
+ac = read_aircraft_model(joinpath(TASOPT.__TASOPTroot__, "../example/defaults/default_wide.toml")) # MODIFY <path> appropriately
 res3 = @benchmark size_aircraft!(ac, iter=50; printiter = false) seconds=30 samples=5
 
 println("Benchmarking HYDROGEN aircraft")

--- a/test/unit_test_fueltank.jl
+++ b/test/unit_test_fueltank.jl
@@ -65,7 +65,7 @@ fuse.layout.cross_section.bubble_lower_downward_shift = 0.3
         TASOPT.tanksize!(ac, 1)
         outputs_mech = TASOPT.CryoTank.size_inner_tank(fuse, fuse_tank, fuse_tank.t_insul)
 
-        outputs_mech_check = (60140.568517238586, 38185.08012765128, 166.77327116515787, [16.41478963327391, 20.306728650515254, 24.618791939176347, 29.34975388954838], 1.8740119151889265, 15.778042937598197, 12.848564428768595)
+        outputs_mech_check = (60104.8235573921, 38147.81559388217, 166.77327116515787, [16.42133035129676, 20.311090752967278, 24.620380536430755, 29.34797626786876], 1.8743852420176998, 15.771807531012154, 12.842701653674803)
         for i in 1:length(outputs_mech)
             @test outputs_mech[i] ≈ outputs_mech_check[i]
         end
@@ -142,20 +142,20 @@ fuse.layout.cross_section.bubble_lower_downward_shift = 0.3
         end
 
         outputs_free = TASOPT.CryoTank.freestream_heat_coeff(z, fuse_tank.TSLtank, Mair, xftank, 240.0)
-        outputs_free_check = (91.1765275792035, 218.06145060705106, 243.3345022554043)
+        outputs_free_check = (91.30101055991513, 218.06145060705106, 243.26644796151263)
         for i in 1:length(outputs_free)
             @test outputs_free[i] ≈ outputs_free_check[i]
         end
 
         outputs_natural = TASOPT.CryoTank.freestream_heat_coeff(0.0, fuse_tank.TSLtank, 0.0, xftank, 287.0, fuse.layout.radius)
-        outputs_natural_check = (1.6786556204397758, 288.2, 288.2)
+        outputs_natural_check = (1.6795624846472137, 288.2, 288.2)
         for i in 1:length(outputs_natural)
             @test outputs_natural[i] ≈ outputs_natural_check[i]
         end
 
         Taw = outputs_free_check[3]
         Rvac = TASOPT.CryoTank.vacuum_resistance(fuse_tank.Tfuel, Taw, 90.0, 100.0)
-        Rvac_check = 0.35637094066735286
+        Rvac_check = 0.3565313051181731
 
         @test Rvac ≈ Rvac_check
     end

--- a/test/unit_test_fueltank.jl
+++ b/test/unit_test_fueltank.jl
@@ -17,8 +17,7 @@ fuse_tank.fueltype = "LH2"
 fuse_tank.placement = "front"
 
 fuse_tank.clearance_fuse = 0.1
-fuse_tank.TSLtank = 288.2
-fuse_tank.TSLtank = 288.2
+TSL = 288.2
 
 fuse_tank.pvent = 2e5
 fuse_tank.ARtank = 2.0
@@ -70,7 +69,7 @@ fuse.layout.cross_section.bubble_lower_downward_shift = 0.3
             @test outputs_mech[i] ≈ outputs_mech_check[i]
         end
         
-        outputs_thermal = TASOPT.CryoTank.tankWthermal(fuse, fuse_tank, z, Mair, xftank, ifuel)
+        outputs_thermal = TASOPT.CryoTank.tankWthermal(fuse, fuse_tank, z, TSL, Mair, xftank, ifuel)
 
         outputs_thermal_check = (1835.8608916011449,)
 
@@ -141,13 +140,13 @@ fuse.layout.cross_section.bubble_lower_downward_shift = 0.3
             @test outputs_h[i] ≈ outputs_h_check[i]
         end
 
-        outputs_free = TASOPT.CryoTank.freestream_heat_coeff(z, fuse_tank.TSLtank, Mair, xftank, 240.0)
+        outputs_free = TASOPT.CryoTank.freestream_heat_coeff(z, TSL, Mair, xftank, 240.0)
         outputs_free_check = (91.30101055991513, 218.06145060705106, 243.26644796151263)
         for i in 1:length(outputs_free)
             @test outputs_free[i] ≈ outputs_free_check[i]
         end
 
-        outputs_natural = TASOPT.CryoTank.freestream_heat_coeff(0.0, fuse_tank.TSLtank, 0.0, xftank, 287.0, fuse.layout.radius)
+        outputs_natural = TASOPT.CryoTank.freestream_heat_coeff(0.0, TSL, 0.0, xftank, 287.0, fuse.layout.radius)
         outputs_natural_check = (1.6795624846472137, 288.2, 288.2)
         for i in 1:length(outputs_natural)
             @test outputs_natural[i] ≈ outputs_natural_check[i]

--- a/test/unit_test_fueltank.jl
+++ b/test/unit_test_fueltank.jl
@@ -18,6 +18,7 @@ fuse_tank.placement = "front"
 
 fuse_tank.clearance_fuse = 0.1
 TSL = 288.2
+fuse_tank.TSLtank = [TSL]
 
 fuse_tank.pvent = 2e5
 fuse_tank.ARtank = 2.0

--- a/test/unit_test_io.jl
+++ b/test/unit_test_io.jl
@@ -87,7 +87,7 @@
     @test size(csv1,1) == 4 #4 rows w default indices
     @test size(csv2,1) == 1 #1 row with addl indices (all)
 
-    @test length(csv1[1]) == 759 # = entries w/ full ac `struct` and in default_output_indices
+    @test length(csv1[1]) == 763 # = entries w/ full ac `struct` and in default_output_indices
     @test length(csv2[1]) == 1147 # = entries w/ full ac `struct` and all output_indices
 
     #test the nested vectors within par arrays


### PR DESCRIPTION
This PR introduces a significant speedup to the tank pressure calculation functions. Most of this is achieved by removing type instabilities that result in slower code. A further speed improvement is achieved in the fuselage heat transfer function by approximating air's $c_p$ as constant.

By defining the aircraft data arrays as `Array` instead of `AbstractArray`, the default aircraft is also sped up.