### PR TITLE
Fix wing fuel usability factor in aircraft sizing

### DIFF
--- a/src/sizing/size_aircraft.jl
+++ b/src/sizing/size_aircraft.jl
@@ -367,17 +367,23 @@ function _size_aircraft!(ac; itermax=35,
 
         # Calculate fuel weight if stored in wings
         Wfmax, dxWfmax, rfmax = 0.0, 0.0, 0.0
-        if (options.has_wing_fuel)
-            Wfmax = 2.0 * ((options.has_centerbox_fuel ? Wfcen : 0.0) + Wfinn + Wfout)
-            dxWfmax = 2.0 * (dxWfinn + dxWfout)
+        if options.has_wing_fuel
+            # TASOPT Eq. 252/253: full geometric fuel capacity and moment
+            # from the wingbox fuel volume.
+            Wfmax_geom = 2.0 * ((options.has_centerbox_fuel ? Wfcen : 0.0) + Wfinn + Wfout)
+            dxWfmax_geom = 2.0 * (dxWfinn + dxWfout)
+
+            # Convert geometric capacity to usable capacity. This lets the
+            # input model represent unusable volume or volume not assigned to fuel.
+            Wfmax = Wfmax_geom * parg[igrWfmax]
+            dxWfmax = dxWfmax_geom * parg[igrWfmax]
+
+            # Use the actual max-payload fuel load to scale the fuel moment.
             Wfuelmp = Wpay - Wpaymax + parg[igWfuel]
             rfmax = Wfuelmp / Wfmax
         end
 
-        # Update wing properties
-        wing.weight = Wwing * rlx + wing.weight * (1.0 - rlx)
         parg[igWfmax] = Wfmax
-        # wing.dxW = dxWwing
         parg[igdxWfuel] = dxWfmax * rfmax
 
         wing.outboard.webs.weight = wing.inboard.webs.weight


### PR DESCRIPTION
**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- fuel_usability_factor was not being used in TASOPT. 
- Now fuel_usability_factor is applied when computing ac.parg[igWfmax].
- In the sizing loop, Wfmax came directly from the geometric wingbox fuel volume. That made the reported maximum fuel capacity and payload-range feasibility checks use raw geometric fuel volume instead of usable fuel capacity.

The updated logic:
- Computes geometric wingbox fuel capacity from TASOPT.pdf docs Eq. 252-254.
- Applies parg[igrWfmax] to get usable fuel capacity.


**AI Statement (required)**

**Limited use of generative AI.**: Used AI to write comments in the code and match equation number to docs.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [ ] All tests are passing
- [x] AI Statement is included
- [ ] The pull request is ready for review
