### PR TITLE
Remedy #2 for Issues #219: Dimension Mismatch and the Optimization of Vertical Tail and Engine Placement 

### DIFF
--- a/src/sizing/size_aircraft.jl
+++ b/src/sizing/size_aircraft.jl
@@ -362,7 +362,7 @@ function _size_aircraft!(ac; itermax=35,
         Wfcen,Wfinn,Wfout,
         dxWfinn,dxWfout,
         dyWfinn,dyWfout,lstrutp = wing_weights!(wing, po, γt, γs,
-                                            Nlift, Weng1, 0, 0.0, 1, wing.layout.ηs,
+                                            Nlift, Weng1, 0, 0.0, 1, yeng - 0.5*wing.layout.span*wing.layout.ηo,
                                             parg[igsigfac], rhofuel)
 
         # Calculate fuel weight if stored in wings
@@ -462,7 +462,7 @@ function _size_aircraft!(ac; itermax=35,
         dfan = parg[igdfan]
         CDAe = parg[igcdefan] * 0.25π * dfan^2
         De = qstall * CDAe
-        Fe = pare[ieFe, ip]
+        Fe = pare[ieFe, iptakeoff] #Assume at u_stall = u_rotate/1.2, one engine goes out, and maximum rated thrust is forced on the other engine to compensate for lost thrust.
 
         # Calculate max eng out moment
         Me = (Fe + De) * yeng
@@ -476,8 +476,28 @@ function _size_aircraft!(ac; itermax=35,
             parg[igCLveout] = Me / (qstall * Sv * lvtail)
         elseif vtail.opt_sizing == TailSizing.OEI
             lvtail = xvtail - xwing
+            lvtail_cg = xvtail - ac.para[iaxCG,iptakeoff,1] #aircraft cg loading condition during emergency landing immediately right after takeoff [m]
             CLveout = parg[igCLveout]
-            Sv = Me / (qstall * CLveout * lvtail)
+            (CLveout > 0) || error("CLveout specified $(CLveout) needs to be positive")
+            (lvtail_cg > 0) || @warn ("Negative or zero lvtail_cg detected: $(lvtail_cg)")
+            #### (Criterion #1) Vertical tail sizing via engine-out yaw power
+            # Add aspect ratio correction for limiting tail lift coefficient under OEI (assuming the reference CLveout input is for typical aircraft with AR = 1.93)
+            slope0 = 2*pi #thin airfoil lift slope assumption
+            effVTail = 0.9 #trapozoidal wing efficiency (between 0.8->0.9), lower give more AR dependency
+            AR_ref = 1.93 #AR for the specified reference CLveout
+            OEI_AR_sensitivity = 0.5 #What portion of the CL limit were affected by AR (Relaxation factor to reduce the effect of AR) (Or else optimal AR goes up to 3.6) (TODO: This is also likely caused by bending and torsion calculation using a separate 5% lift loss coefficient indepdent of AR)
+            CL_AR_scaling = (1.0+slope0/(pi*effVTail*AR_ref))/(1.0+slope0/(pi*effVTail*vtail.layout.AR)) #CLact/CLref = (1+a0/pi/e/ARref)/(1+a0/pi/e/ARact)
+            CLveout_act = CLveout * (1.0 + OEI_AR_sensitivity*(CL_AR_scaling-1.0)) #From finite wing lift slope scaling due to induced downwash
+            # Size the vertical tail
+            Sv_OEI = Me / (qstall * CLveout_act * lvtail_cg)
+            (Sv_OEI > 0) || @warn "Negative or zero Sv_OEI detected: $(Sv_OEI)"
+            #### (Criterion #2) Vertical tail sizing via yaw acceleration authority
+            Izz = calculate_Izz(ac) #aircraft yaw moment of inertial around cg (kgm2)
+            omega_dot_req = 0.055 #maximum yawing angular acceleration required near stalling or landing with strong crosswind (1/s2)
+            Sv_YA = (omega_dot_req*Izz)/CLveout_act/lvtail_cg/qstall
+            (Sv_YA > 0) || @warn "Negative or zero Sv_YA detected: $(Sv_YA)"
+            #### Compute derived variables
+            Sv = max(Sv_OEI,Sv_YA)
             vtail.layout.S = Sv
             vtail.volume = Sv * lvtail / (wing.layout.S * wing.layout.span)
         end
@@ -491,6 +511,12 @@ function _size_aircraft!(ac; itermax=35,
         bv = bv2 / 2
         vtail.layout.span = bv2
         vtail.layout.ηs = vtail.layout.ηo
+
+        # Correct the vertical tail location if the trailing edge of vertical tail were sitting behind the tail cone
+        dx_vtailEnd_to_coneEnd = vtail.layout.box_x + 0.5*vtail.layout.root_chord - fuse.layout.x_cone_end
+        if dx_vtailEnd_to_coneEnd > 0 #If your vtail were not physically attached to fuselage, there is gonna a problem
+            vtail.layout.box_x -= dx_vtailEnd_to_coneEnd #This will constrain how low AR for vtail can be. If too low, vtail moment arm has to decrease. 
+        end
 
         # HT weight
         htail.weight, _ = wing_weights!(htail, poh, htail.outboard.λ, htail.inboard.λ,

--- a/src/structures/calculate_centroid_offset.jl
+++ b/src/structures/calculate_centroid_offset.jl
@@ -89,3 +89,48 @@ function calculate_centroid_offset!(tail::Tail, b::Float64, λs::Float64)
                   tail.layout.sweep)
       tail.layout.x = tail.layout.box_x + dx         
 end
+
+"""
+      calculate_Izz(ac)
+
+This function calculate the momentum of inertial around z axis(vertical) through the CG of the aircraft at takeoff phase from the design mission
+
+      **Inputs**
+            - ac: tasopt aircraft model
+      **outputs**
+            - Izz: moment of inertial (kg*m^2)
+      **behavior**
+            - Only rough estimation, assume uniform mass distribution in each big component
+            - Intended to be used during sizing for vtail sizing for yawing acceleration authority
+"""
+function calculate_Izz(ac)
+      # Weight lumping
+      m_fuse_tot = (ac.parg[igWpaymax] + ac.fuselage.weight + ac.parg[igWftank] + ac.parg[igWtesys] +
+                   ac.parg[igWMTO]*ac.fuselage.HPE_sys.W + ac.landing_gear.nose_gear.weight.W + 
+                   ac.landing_gear.main_gear.weight.W)/gee  #[kg]
+      m_wing_tot = (ac.wing.weight + ac.wing.strut.weight + ac.parg[igWfmax])/gee #[kg]
+      m_htail_tot = ac.htail.weight/gee #[kg]
+      m_vtail_tot = ac.vtail.weight/gee #[kg]
+      m_eng_tot = ac.parg[igWeng]/gee #[kg]
+      # Component I
+      Izz0_fuse = m_fuse_tot*(ac.fuselage.layout.cross_section.radius^2/4.0 + ac.fuselage.layout.x_cone_end^2/12.0) #(xfuse/2, 0)
+      Izz0_wing = m_wing_tot*((0.5*ac.wing.layout.root_chord*(ac.wing.outboard.λ + 1.0))^2 + ac.wing.layout.span^2)/12.0 #(xwing, 0)
+      Izz0_htail = m_htail_tot*((0.5*ac.htail.layout.root_chord*(ac.htail.outboard.λ + 1.0))^2 + ac.htail.layout.span^2)/12.0 #(xhtail, 0)
+      Izz0_vtail = m_vtail_tot*((0.5*ac.vtail.layout.root_chord*(ac.vtail.outboard.λ + 1.0))^2)/12.0 #(xvtail,0)
+      Izz0_engine = 0.0
+      # Total I
+      Izz = m_fuse_tot*(ac.fuselage.layout.x_cone_end/2.0 - ac.para[iaxCG,iptakeoff,1])^2 + 
+            m_wing_tot*(ac.wing.layout.x - ac.para[iaxCG,iptakeoff,1])^2 + 
+            m_htail_tot*(ac.htail.layout.x - ac.para[iaxCG,iptakeoff,1])^2 +
+            m_vtail_tot*(ac.vtail.layout.x - ac.para[iaxCG,iptakeoff,1])^2 +
+            m_eng_tot*((ac.parg[igxeng]-ac.para[iaxCG,iptakeoff,1])^2 + ac.parg[igyeng]^2)+
+            Izz0_fuse +
+            Izz0_wing +
+            Izz0_htail + 
+            Izz0_vtail +
+            Izz0_engine
+      #Sanity check for debugging
+      # kz = sqrt(Izz/(m_fuse_tot+m_wing_tot+m_htail_tot+m_vtail_tot+m_eng_tot))/ac.wing.layout.span
+      # println("Is kz: $(kz) roughly 0.25->0.35?")
+      return Izz
+end

--- a/src/structures/size_landing_gear.jl
+++ b/src/structures/size_landing_gear.jl
@@ -32,7 +32,7 @@ function size_landing_gear!(ac)
         l_tailstrike = (fuse.layout.x_end - x_lg) * tan(tailstrike_angle) - 2*fuse.layout.radius
 
         #Next, find the nose length that gives desired engine ground clearance
-        yeng = wing.layout.ηs * wing.layout.span / 2
+        yeng = ac.parg[igyeng]
         ground_clearance = landing_gear.engine_ground_clearance
         dihedral_angle = landing_gear.wing_dihedral_angle
         Deng = parg[igdfan]

--- a/src/structures/structures.jl
+++ b/src/structures/structures.jl
@@ -16,7 +16,7 @@ import ..TASOPT: __TASOPTindices__, __TASOPTroot__, unpack_ac, unpack_ac_compone
 
 export wing_weights!, calculate_centroid_offset!, calculate_centroid_offset, fusew!,
  update_fuse!, update_fuse_for_pax!, place_cabin_seats, find_cabin_width, find_floor_angles, arrange_seats,
-size_landing_gear!
+size_landing_gear!, calculate_Izz
 
 include(joinpath(__TASOPTroot__,"data_structs/index.inc"))
 include(joinpath(__TASOPTroot__,"utils/constants.jl"))

--- a/src/structures/wing_weights.jl
+++ b/src/structures/wing_weights.jl
@@ -86,9 +86,9 @@ Also returns the material gauges, torsional and bending stiffness. Formerly, `ge
     - `Nload::Int`: Max vertical load factor for wing bending loads.
     - `We::Float64`: Weight of the engine.
     - `neout::Int`:  Number of engines mounted outboard of the wing break (strut attachment point).
-    - `dyeout::Float64`: Spanwise moment arm for outboard engines, measured from the wing break station.
+    - `dyeout::Float64`: Spanwise moment arm for outboard engines, measured outward positive from the wing break station [m].
     - `neinn::Int`: Number of engines mounted inboard of the wing break (strut attachment point).
-    - `dyeinn::Float64`: Spanwise moment arm for inboard engines, measured from the wing break station.
+    - `dyeinn::Float64`: Spanwise moment arm for inboard engines, measured outward positive from the wing root half span ηₒ [m]
     - `sigfac::Float64`: Stress Factor.
     - `rhofuel::Float64`: Density of the fuel.
     - `n_wings::Int64`: Number of total wings (1 for Vtail).
@@ -106,6 +106,38 @@ function wing_weights!(wing, po, gammat, gammas,
     # Calculate non-dim span coordinate at span break and root (ηs and ηo resp.)
     etao = wing.layout.ηo
     etas = wing.layout.ηs
+
+    # Correct mis-classification for engine placement
+    ys = 0.5*wing.layout.span*etas #[m] span break from the centerline
+    yo = 0.5*wing.layout.span*etao #[m] wing root from the centerline
+    dyeout_cen = dyeout + ys #[m] outer engine from the centerline
+    dyeinn_cen = dyeinn + yo #[m] inner engine from the centerline
+    eps_span = wing.layout.span*1e-8 #[m] small tolerance for span
+    neout = max(0,neout)
+    neinn = max(0,neinn)
+    netot = neout + neinn
+    if (netot<=0)
+        dyeout = 0.0
+        dyeinn = 0.0
+        neout = 0
+        neinn = 0
+    elseif (dyeout_cen>(ys+eps_span)) && (dyeinn_cen>(ys+eps_span)) #Both set of engines are outside wing span break
+        dyeout = (dyeout_cen*neout + dyeinn_cen*neinn)/(netot) - ys # Assume all engines have the same unit weight
+        neout = netot
+        dyeinn = 0.0
+        neinn = 0
+    elseif (dyeout_cen<=(ys+eps_span)) && (dyeinn_cen>(ys+eps_span)) #Outer ones inside but inner ones outside
+        dyeout = dyeinn_cen - ys
+        dyeinn = dyeout_cen - yo
+        neout_dum = neout
+        neout = neinn
+        neinn = neout_dum
+    elseif (dyeout_cen<=(ys+eps_span)) && (dyeinn_cen<=(ys+eps_span)) #Both set of engines are inside
+        dyeinn = (dyeout_cen*neout + dyeinn_cen*neinn)/(netot) - yo
+        neinn = netot
+        dyeout = 0.0
+        neout = 0
+    end #Normal case stays unchanged
 
     # Tip roll off Lift (modeled as a point load) and it's moment about ηs
     dLt = wing.tip_lift_loss * po * wing.layout.root_chord * gammat * wing.outboard.λ


### PR DESCRIPTION
This PR implements the proposed remedy #2 for the issues raised in the post #219: Dimension Mismatch and the Optimization of Vertical Tail and Engine Placement 

The specific issues resolved by the current PR are copied from the original post #219 and listed below.

1. Engine span-wise location from the inputs to the `wing_weights!` function should be a dimensional number (Ex. wing.layout.ηs*b/2) instead of a non-dimensional one (wing.layout.ηs) 
https://github.com/MIT-LAE/TASOPT.jl/blob/b9be1deb59879d5be3b3f4d9a964d173a4fc20e0/src/sizing/size_aircraft.jl#L365

2. Engine span-wise location used to calculate the wing root bending stress relief is assumed to be the span-break location `ηs` which is different from the engine span-wise location `ac[igyeng]` used to calculate the vertical tail size.
https://github.com/MIT-LAE/TASOPT.jl/blob/b9be1deb59879d5be3b3f4d9a964d173a4fc20e0/src/sizing/size_aircraft.jl#L365 versus
https://github.com/MIT-LAE/TASOPT.jl/blob/b9be1deb59879d5be3b3f4d9a964d173a4fc20e0/src/sizing/size_aircraft.jl#L468
      2.1. Engine span-wise location used to calculate landing gear weight is also assumed to be the span-break location `ηs`, independent of `ac[igyeng]`.
https://github.com/MIT-LAE/TASOPT.jl/blob/b9be1deb59879d5be3b3f4d9a964d173a4fc20e0/src/structures/size_landing_gear.jl#L35

3. The `wing_weights!` function separates engines' span-wise placements into the placement outwards from the wing span-break location `dyeout` and the placement inwards `dyeinn`. The outward placement affects the structure of both inner and outer wing panels, while the inward one affects only the inner panel. However, there is a lack of sanity check to make sure the outward placement is truly outward of the span-break location and similarly for the inward one. This becomes dangerous if both engine placements and wing span-break location are optimized simultaneously.
https://github.com/MIT-LAE/TASOPT.jl/blob/b9be1deb59879d5be3b3f4d9a964d173a4fc20e0/src/structures/wing_weights.jl#L99
 
4. The user specified aspect ratio for the vertical tail `ac.vtail.layout.AR` is used to determine the weights of the vertical tail and aircraft tail cone, with the general effect that a larger vertical tail's AR will lead to a heavier aircraft weight.
The bending moment at the root of the vertical tail is proportional to its span:
https://github.com/MIT-LAE/TASOPT.jl/blob/b9be1deb59879d5be3b3f4d9a964d173a4fc20e0/src/structures/wing_weights.jl#L124
The torsion stress on the aircraft tail cone is proportional to the span of the vertical tail:
https://github.com/MIT-LAE/TASOPT.jl/blob/b9be1deb59879d5be3b3f4d9a964d173a4fc20e0/src/structures/fuseW.jl#L292
The vertical tail AR is then not use in other calculations. During optimization, `ac.vtail.layout.AR` is optimized to be as small as possible due to its sole passive effect to the aircraft performance, which is not realistic.

**Changes proposed in this pull request**

- Solution to sub-issue `1. (#2Fix)`: 
   File change: [‎src/structures/wing_weights.jl](https://github.com/ychen172/TASOPT.jl/commit/dd1c788eaeb6def2cf4649a51f6c1c0214fae73b#diff-8b63cf3e1286c151cae5866c7b63d0fb7856d11caeabc98e1ed1070ff07762c0)
   Lines of change: 89, 91: Update docstring to correct the descriptions of engine placement inputs.
   
   File change:[‎src/sizing/size_aircraft.jl‎](https://github.com/ychen172/TASOPT.jl/commit/dd1c788eaeb6def2cf4649a51f6c1c0214fae73b#diff-9a1bdc402d216566b238f419b889469d600a29237ab20966b41a87e25219bd0a)
   Lines of change: 365: Replace the non-dimensional input with a dimensional one.

- Solution to sub-issu `2. (#2Fix)`:
    File change:[‎src/sizing/size_aircraft.jl‎](https://github.com/ychen172/TASOPT.jl/commit/dd1c788eaeb6def2cf4649a51f6c1c0214fae73b#diff-9a1bdc402d216566b238f419b889469d600a29237ab20966b41a87e25219bd0a)
   Lines of change: 365: Use the same yengine for both `OEI` sizing and wing root bending stress relief.
   Lines of change: 465: Use more conservative takeoff thrust for `OEI` sizing.
   Lines of change: 479: Add another vtail moment arm from CG for moment balancing.
   Lines of change: 481, 482, 493: Sanity check for invalid user inputs.
   Lines of change: 494->500: Add an additional criterion to size vertical tail by yaw acceleration requirement

   File change:[‎src/structures/calculate_centroid_offset.jl‎](https://github.com/ychen172/TASOPT.jl/commit/dd1c788eaeb6def2cf4649a51f6c1c0214fae73b#diff-56f5789ba1ca5730a68d26fb012341d98d3bc58204377554e103d4d336a146bf)
   Lines of change: 93->136: Calculate moment of inertial Izz for the yaw acceleration vtail sizing criterion

   File change:[‎src/structures/structures.jl‎](https://github.com/ychen172/TASOPT.jl/commit/dd1c788eaeb6def2cf4649a51f6c1c0214fae73b#diff-52161a7d3f80d0ca76b7ddc0ec0cbbf161667ae81bd94b3988405c4035a22517)
   Lines of change: 19: Expose calculate_Izz function to be used by size aircraft function call

- Solution to sub-issu `2.1. (#2Fix)`:
   File change:[‎src/structures/size_landing_gear.jl‎](https://github.com/ychen172/TASOPT.jl/commit/dd1c788eaeb6def2cf4649a51f6c1c0214fae73b#diff-bea3e0be14866691c832d428f04aecc7c5d6a3e9b7527c84e4ba037f05a7720b)
   Lines of change: 35: Use user specified yengine for landing gear sizing.

- Solution to sub-issu `3. (#2Fix)`:
   File change:[‎src/structures/wing_weights.jl‎](https://github.com/ychen172/TASOPT.jl/commit/dd1c788eaeb6def2cf4649a51f6c1c0214fae73b#diff-8b63cf3e1286c151cae5866c7b63d0fb7856d11caeabc98e1ed1070ff07762c0)
   Lines of change: 110->141: Sanity check and the reclassification for the span-wise location of inner and outer engines.

- Solution to sub-issu `4. (#2Fix)`:
   File change:[‎src/sizing/size_aircraft.jl‎](https://github.com/ychen172/TASOPT.jl/commit/dd1c788eaeb6def2cf4649a51f6c1c0214fae73b#diff-9a1bdc402d216566b238f419b889469d600a29237ab20966b41a87e25219bd0a)
   Lines of change: 483->492: Implement the AR effect on the vtail performance for vtail AR sizing.
   Lines of change: 515->520: Implement the geometric constraint on vtail placement for vtail AR sizing.

**If applicable, fill in the issue number this pull request is fixing**

Closes #219

**If applicable, provide an example illustrating new features this pull request is introducing**

I am working on it.

Also, can work on new regression test too if plan on approval.

**AI Statement (required)**

- **Limited use of generative AI.**
  Standard or boilerplate code snippets were generated with AI and manually reviewed;
  all design, logic, and implementation decisions were made by the contributor.
  Examples: IDE code-completions or brief LLM queries for common patterns.

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] All tests are passing
- [ ] AI Statement is included
- [ ] The pull request is ready for review
